### PR TITLE
Phase 3: expand VM node coverage + VM goldens

### DIFF
--- a/examples/golden/vm_default_is_canonical.out.aos
+++ b/examples/golden/vm_default_is_canonical.out.aos
@@ -1,1 +1,1 @@
-Err#vm_emit_err(code=VM001 message="Unsupported construct in bytecode mode: Import." nodeId=imp1)
+Err#vm_emit_err(code=VM001 message="Import file not found: ./missing.aos" nodeId=imp1)

--- a/examples/golden/vm_import_support.in.aos
+++ b/examples/golden/vm_import_support.in.aos
@@ -1,0 +1,4 @@
+Program#p1 {
+  Import#i1(path="./mod.aos")
+  Call#c1(target=io.print) { Lit#s1(value="import-ok") }
+}

--- a/examples/golden/vm_import_support.out.aos
+++ b/examples/golden/vm_import_support.out.aos
@@ -1,0 +1,2 @@
+import-ok
+Ok#ok1(type=void)

--- a/examples/golden/vm_map_field.in.aos
+++ b/examples/golden/vm_map_field.in.aos
@@ -1,0 +1,9 @@
+Program#p1 {
+  Let#l1(name=m) {
+    Map#m1 {
+      Field#f1(key="status") { Lit#s1(value="ok") }
+      Field#f2(key="ready") { Lit#b1(value=true) }
+    }
+  }
+  Call#c1(target=io.print) { Call#c2(target=compiler.toJson) { Var#v1(name=m) } }
+}

--- a/examples/golden/vm_map_field.out.aos
+++ b/examples/golden/vm_map_field.out.aos
@@ -1,0 +1,2 @@
+{"ready":true,"status":"ok"}
+Ok#ok1(type=void)

--- a/examples/golden/vm_node_shapes.in.aos
+++ b/examples/golden/vm_node_shapes.in.aos
@@ -1,0 +1,17 @@
+Program#p1 {
+  Let#l1(name=evt) { Event#Message(type="http.request" payload="GET /health") }
+  Let#l2(name=cmd) { Command#Print(text="ok") }
+  Let#l3(name=req) { HttpRequest#h1(method="GET" path="/health") }
+  Let#l4(name=route) { Route#r1(path="/health" handler="health") }
+  Let#l5(name=match) { Match#m1(handler="health") }
+  Call#c1(target=io.print) { NodeKind#k1 { Var#v1(name=evt) } }
+  Call#c2(target=io.print) { NodeKind#k2 { Var#v2(name=cmd) } }
+  Call#c3(target=io.print) { NodeKind#k3 { Var#v3(name=req) } }
+  Call#c4(target=io.print) { NodeKind#k4 { Var#v4(name=route) } }
+  Call#c5(target=io.print) { NodeKind#k5 { Var#v5(name=match) } }
+  If#if1 {
+    Eq#eq1 { Lit#n1(value=null) Lit#n2(value=null) }
+    Block#b1 { Call#c6(target=io.print) { Lit#s1(value="null-ok") } }
+    Block#b2 { Call#c7(target=io.print) { Lit#s2(value="null-bad") } }
+  }
+}

--- a/examples/golden/vm_node_shapes.out.aos
+++ b/examples/golden/vm_node_shapes.out.aos
@@ -1,0 +1,7 @@
+Event
+Command
+HttpRequest
+Route
+Match
+null-ok
+Ok#ok1(type=void)

--- a/examples/golden/vm_unsupported_construct.err
+++ b/examples/golden/vm_unsupported_construct.err
@@ -1,1 +1,1 @@
-Err#vm_emit_err(code=VM001 message="Unsupported construct in bytecode mode: Import." nodeId=imp1)
+Err#vm_emit_err(code=VM001 message="Unsupported construct in bytecode mode: Project." nodeId=proj1)

--- a/examples/golden/vm_unsupported_construct.in.aos
+++ b/examples/golden/vm_unsupported_construct.in.aos
@@ -1,3 +1,3 @@
 Program#p1 {
-  Import#imp1(path="./missing.aos")
+  Project#proj1(name="x" entryFile="main.aos" entryExport="start")
 }


### PR DESCRIPTION
## Summary
- extend AiBC1 compile/run support for additional runtime node operations and node-literal construction
- add bytecode import flattening for exported lets during `compiler.emitBytecode`
- add VM goldens for import support, map/field, and structured node literal coverage
- update VM default and unsupported-construct goldens to deterministic VM001 behavior

## Verification
- `dotnet test AiLang.slnx`
- `src/AiLang.Cli/bin/Debug/net10.0/airun run --vm=ast src/compiler/aic.aos test examples/golden`

Closes #3