### PR TITLE
Phase 3: production bytecode-only build mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ The AI must treat architectural constraints as hard rules.
 
 - Use `./tools/airun` for day-to-day execution.
 - VM is default for `run`; use `--vm=ast` only for debugging unsupported bytecode paths.
+- Production runtime builds (`AosDevMode=false`) disable `--vm=ast` and source-mode commands.
 - Use `./scripts/test.sh` for golden test validation.
 - Use `./scripts/build-airun.sh` only when rebuilding `tools/airun` via dotnet publish.
 - Do not use `dotnet run` or `dotnet test` for normal workflow.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Dotnet is only required for `scripts/build-airun.sh`.
 - Canonical runtime: AiBC1 bytecode VM (default).
 - AST interpreter: debug-only fallback via `--vm=ast`.
 - New publish artifacts embed bytecode payloads by default.
+- Build flag: `AosDevMode=false` creates a production runtime build with AST mode disabled.
 
 ## Examples
 

--- a/src/AiLang.Cli/AiLang.Cli.csproj
+++ b/src/AiLang.Cli/AiLang.Cli.csproj
@@ -10,6 +10,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AosDevMode Condition="'$(AosDevMode)'==''">true</AosDevMode>
+    <DefineConstants Condition="'$(AosDevMode)'=='true'">$(DefineConstants);AOS_DEV_MODE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/AiLang.Core/AiLang.Core.csproj
+++ b/src/AiLang.Core/AiLang.Core.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <AosDevMode Condition="'$(AosDevMode)'==''">true</AosDevMode>
+    <DefineConstants Condition="'$(AosDevMode)'=='true'">$(DefineConstants);AOS_DEV_MODE</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- add build property `AosDevMode` to core + cli projects and define `AOS_DEV_MODE` when enabled
- enforce production-mode runtime guardrails in CLI:
  - `--vm=ast` rejected with deterministic `Err`
  - AST embedded bundle payloads rejected in production builds
  - `repl`, source `run`, and source `serve` rejected in production builds
- keep dev-mode behavior unchanged so existing workflow and goldens stay green
- document production mode in README and AGENTS

## Verification
- `dotnet test AiLang.slnx`
- `./scripts/test.sh`
- `dotnet build src/AiLang.Cli/AiLang.Cli.csproj -c Release -p:AosDevMode=false`
- `dotnet src/AiLang.Cli/bin/Release/net10.0/airun.dll run examples/hello.aos` (returns deterministic `Err#...DEV004`)

Closes #4
