### PR TITLE
Phase 3: eliminate hidden AST fallback in default mode

### DIFF
--- a/src/AiLang.Cli/Program.cs
+++ b/src/AiLang.Cli/Program.cs
@@ -396,6 +396,12 @@ static int RunEmbeddedBundle(string bundleText, string[] cliArgs, bool traceEnab
 {
     try
     {
+        if (string.Equals(vmMode, "bytecode", StringComparison.Ordinal))
+        {
+            Console.WriteLine(FormatErr("err1", "VM001", "Embedded AST bundle requires --vm=ast.", "bundle"));
+            return 3;
+        }
+
         var parse = Parse(bundleText);
         if (parse.Root is null || parse.Diagnostics.Count > 0)
         {
@@ -425,8 +431,7 @@ static int RunEmbeddedBundle(string bundleText, string[] cliArgs, bool traceEnab
         runtime.ModuleBaseDir = Path.GetDirectoryName(Environment.ProcessPath ?? AppContext.BaseDirectory) ?? Directory.GetCurrentDirectory();
         runtime.Env["argv"] = AosValue.FromNode(BuildArgvNode(cliArgs));
         runtime.ReadOnlyBindings.Add("argv");
-        var bundleVmMode = string.Equals(vmMode, "bytecode", StringComparison.Ordinal) ? "ast" : vmMode;
-        runtime.Env["__vm_mode"] = AosValue.FromString(bundleVmMode);
+        runtime.Env["__vm_mode"] = AosValue.FromString(vmMode);
         runtime.ReadOnlyBindings.Add("__vm_mode");
         runtime.Env["__entryArgs"] = AosValue.FromNode(BuildArgvNode(cliArgs));
         runtime.ReadOnlyBindings.Add("__entryArgs");


### PR DESCRIPTION
## Summary
- remove implicit AST fallback for embedded AST bundles when runtime mode is bytecode
- return deterministic `Err#...(code=VM001 ...)` unless AST mode is explicitly requested
- preserve explicit `--vm=ast` behavior for embedded AST bundles

## Verification
- `dotnet test AiLang.slnx`
- `./scripts/test.sh`

Closes #6
