### PR TITLE
Issue 21: manifest Include validation foundation

### DIFF
--- a/SPEC/IL.md
+++ b/SPEC/IL.md
@@ -14,7 +14,8 @@ This file is normative for the executable AiLang IL subset used by `aic run`.
 | `Call` | `target` (identifier/dotted identifier) | `0..N` | Native or user-defined call. |
 | `Import` | `path` (string, relative) | `0` | Loads another module and merges explicit exports. |
 | `Export` | `name` (identifier) | `0` | Exposes one binding from current module. |
-| `Project` | `name` (string), `entryFile` (string), `entryExport` (string) | `0` | Project manifest node for `project.aiproj`. |
+| `Project` | `name` (string), `entryFile` (string), `entryExport` (string) | `0..N` | Project manifest node for `project.aiproj`; children must be `Include`. |
+| `Include` | `name` (string), `path` (string, relative), `version` (string) | `0` | Declares library include metadata for project-level dependency resolution. |
 | `If` | none | `2..3` | Condition, then-branch, optional else-branch. |
 | `Eq` | none | `2` | Value equality. |
 | `StrConcat` | none | `2` | String concatenation. |

--- a/examples/golden/manifest_include_absolute_path.err
+++ b/examples/golden/manifest_include_absolute_path.err
@@ -1,0 +1,1 @@
+Err#diag0(code=VAL154 message="Include path must be relative path." nodeId=inc1)

--- a/examples/golden/manifest_include_absolute_path.in.aos
+++ b/examples/golden/manifest_include_absolute_path.in.aos
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="myapp" entryFile="src/main.aos" entryExport="main") {
+    Include#inc1(name="AiVectra" path="/abs/libs/aivectra" version="0.1.0")
+  }
+}

--- a/examples/golden/manifest_include_missing_version.err
+++ b/examples/golden/manifest_include_missing_version.err
@@ -1,0 +1,1 @@
+Err#diag0(code=VAL002 message="Missing attribute 'version'." nodeId=inc1)

--- a/examples/golden/manifest_include_missing_version.in.aos
+++ b/examples/golden/manifest_include_missing_version.in.aos
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="myapp" entryFile="src/main.aos" entryExport="main") {
+    Include#inc1(name="AiVectra" path="libs/aivectra")
+  }
+}

--- a/examples/golden/manifest_include_valid.in.aos
+++ b/examples/golden/manifest_include_valid.in.aos
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="myapp" entryFile="src/main.aos" entryExport="main") {
+    Include#inc1(name="AiVectra" path="libs/aivectra" version="0.1.0")
+  }
+}

--- a/examples/golden/manifest_include_valid.out.aos
+++ b/examples/golden/manifest_include_valid.out.aos
@@ -1,0 +1,1 @@
+Program#p1 { Project#proj1(entryExport="main" entryFile="src/main.aos" name="myapp") { Include#inc1(name="AiVectra" path="libs/aivectra" version="0.1.0") } }

--- a/src/AiLang.Core/AosValidator.cs
+++ b/src/AiLang.Core/AosValidator.cs
@@ -126,7 +126,7 @@ public sealed class AosValidator
                 RequireAttr(node, "name");
                 RequireAttr(node, "entryFile");
                 RequireAttr(node, "entryExport");
-                RequireChildren(node, 0, 0);
+                RequireChildren(node, 0, int.MaxValue);
                 if (node.Attrs.TryGetValue("entryFile", out var entryFileAttr))
                 {
                     if (entryFileAttr.Kind != AosAttrKind.String)
@@ -151,6 +151,46 @@ public sealed class AosValidator
                     else if (string.IsNullOrEmpty(entryExportAttr.AsString()))
                     {
                         _diagnostics.Add(new AosDiagnostic("VAL095", "Project entryExport must be non-empty.", node.Id, node.Span));
+                    }
+                }
+                foreach (var child in node.Children)
+                {
+                    if (child.Kind != "Include")
+                    {
+                        _diagnostics.Add(new AosDiagnostic("VAL150", "Project children must be Include nodes.", child.Id, child.Span));
+                        continue;
+                    }
+                    ValidateNode(child, env, permissions);
+                }
+                return AosValueKind.Void;
+            case "Include":
+                RequireAttr(node, "name");
+                RequireAttr(node, "path");
+                RequireAttr(node, "version");
+                RequireChildren(node, 0, 0);
+                if (node.Attrs.TryGetValue("name", out var includeNameAttr))
+                {
+                    if (includeNameAttr.Kind != AosAttrKind.String || string.IsNullOrEmpty(includeNameAttr.AsString()))
+                    {
+                        _diagnostics.Add(new AosDiagnostic("VAL151", "Include name must be non-empty string.", node.Id, node.Span));
+                    }
+                }
+                if (node.Attrs.TryGetValue("version", out var versionAttr))
+                {
+                    if (versionAttr.Kind != AosAttrKind.String || string.IsNullOrEmpty(versionAttr.AsString()))
+                    {
+                        _diagnostics.Add(new AosDiagnostic("VAL152", "Include version must be non-empty string.", node.Id, node.Span));
+                    }
+                }
+                if (node.Attrs.TryGetValue("path", out var includePathAttr))
+                {
+                    if (includePathAttr.Kind != AosAttrKind.String)
+                    {
+                        _diagnostics.Add(new AosDiagnostic("VAL153", "Include path must be string.", node.Id, node.Span));
+                    }
+                    else if (Path.IsPathRooted(includePathAttr.AsString()))
+                    {
+                        _diagnostics.Add(new AosDiagnostic("VAL154", "Include path must be relative path.", node.Id, node.Span));
                     }
                 }
                 return AosValueKind.Void;


### PR DESCRIPTION
## Summary
- add `Include` node support to project manifest validation
- allow `Project` to contain `Include` children and validate include shape deterministically
- add validation rules for include metadata:
  - required `name`, `path`, `version`
  - non-empty `name` and `version`
  - `path` must be relative
- update `SPEC/IL.md` to include `Include` node contract
- add manifest include goldens for valid + failure cases

## Verification
- `src/AiLang.Cli/bin/Debug/net10.0/airun run --vm=ast src/compiler/aic.aos test examples/golden`

Refs #21
