### PR TITLE
Issue #21: include-aware publish validation and fixtures

### DIFF
--- a/examples/golden/publish_include_missing_library.in.aos
+++ b/examples/golden/publish_include_missing_library.in.aos
@@ -1,0 +1,1 @@
+Program#pim1 { Lit#pim2(value=0) }

--- a/examples/golden/publish_include_missing_library.out.aos
+++ b/examples/golden/publish_include_missing_library.out.aos
@@ -1,0 +1,1 @@
+Err#publish_err(code=PUB015 message="Included library not found: AiVectra" nodeId=inc1)

--- a/examples/golden/publish_include_success.in.aos
+++ b/examples/golden/publish_include_success.in.aos
@@ -1,0 +1,1 @@
+Program#pis1 { Lit#pis2(value=0) }

--- a/examples/golden/publish_include_success.out.aos
+++ b/examples/golden/publish_include_success.out.aos
@@ -1,0 +1,1 @@
+Ok#ok1(type=string value="publish-complete")

--- a/examples/golden/publish_include_version_mismatch.in.aos
+++ b/examples/golden/publish_include_version_mismatch.in.aos
@@ -1,0 +1,1 @@
+Program#piv1 { Lit#piv2(value=0) }

--- a/examples/golden/publish_include_version_mismatch.out.aos
+++ b/examples/golden/publish_include_version_mismatch.out.aos
@@ -1,0 +1,1 @@
+Err#publish_err(code=PUB019 message="Included library version mismatch for AiVectra: expected 0.2.0, got 0.1.0." nodeId=inc1)

--- a/examples/golden/publishcases/include_missing_library/main.aos
+++ b/examples/golden/publishcases/include_missing_library/main.aos
@@ -1,0 +1,4 @@
+Program#p1 {
+  Let#l1(name=start) { Lit#i1(value=0) }
+  Export#e1(name=start)
+}

--- a/examples/golden/publishcases/include_missing_library/project.aiproj
+++ b/examples/golden/publishcases/include_missing_library/project.aiproj
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="app_include_missing" entryFile="main.aos" entryExport="start") {
+    Include#inc1(name="AiVectra" path="libs/aivectra" version="0.1.0")
+  }
+}

--- a/examples/golden/publishcases/include_success/libs/aivectra/AiVectra.ailib
+++ b/examples/golden/publishcases/include_success/libs/aivectra/AiVectra.ailib
@@ -1,0 +1,3 @@
+Program#p1 {
+  Project#proj1(name="AiVectra" entryFile="src/lib.aos" entryExport="library" version="0.1.0")
+}

--- a/examples/golden/publishcases/include_success/main.aos
+++ b/examples/golden/publishcases/include_success/main.aos
@@ -1,0 +1,4 @@
+Program#p1 {
+  Let#l1(name=start) { Lit#i1(value=0) }
+  Export#e1(name=start)
+}

--- a/examples/golden/publishcases/include_success/project.aiproj
+++ b/examples/golden/publishcases/include_success/project.aiproj
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="app_include_ok" entryFile="main.aos" entryExport="start") {
+    Include#inc1(name="AiVectra" path="libs/aivectra" version="0.1.0")
+  }
+}

--- a/examples/golden/publishcases/include_version_mismatch/libs/aivectra/AiVectra.ailib
+++ b/examples/golden/publishcases/include_version_mismatch/libs/aivectra/AiVectra.ailib
@@ -1,0 +1,3 @@
+Program#p1 {
+  Project#proj1(name="AiVectra" entryFile="src/lib.aos" entryExport="library" version="0.1.0")
+}

--- a/examples/golden/publishcases/include_version_mismatch/main.aos
+++ b/examples/golden/publishcases/include_version_mismatch/main.aos
@@ -1,0 +1,4 @@
+Program#p1 {
+  Let#l1(name=start) { Lit#i1(value=0) }
+  Export#e1(name=start)
+}

--- a/examples/golden/publishcases/include_version_mismatch/project.aiproj
+++ b/examples/golden/publishcases/include_version_mismatch/project.aiproj
@@ -1,0 +1,5 @@
+Program#p1 {
+  Project#proj1(name="app_include_version_mismatch" entryFile="main.aos" entryExport="start") {
+    Include#inc1(name="AiVectra" path="libs/aivectra" version="0.2.0")
+  }
+}


### PR DESCRIPTION
## Summary
- extend host compiler.publish to validate Project Include dependencies during publish
- support library-mode publish (entryExport="library") writing deterministic .ailib metadata
- add include publish golden fixtures and cases for success, missing library, and version mismatch

## Validation
- dotnet test AiLang.slnx --no-restore
- src/AiLang.Cli/bin/Debug/net10.0/airun run --vm=ast src/compiler/aic.aos test examples/golden
