### PR TITLE
Update architecture docs for issue 38

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,24 @@ The AI must treat architectural constraints as hard rules.
 - VM execution must not directly access time, randomness, network, filesystem, or process state.
 - Syscalls are the only permitted escape hatch from deterministic execution.
 
+## Layer boundaries (enforced)
+
+- `src/AiLang.Core` is language-only:
+  - parser/tokenizer bridge
+  - AST/IR structures
+  - validator and deterministic language semantics
+  - no direct syscall, network, file, or process operations
+- `src/AiVM.Core` is VM-only:
+  - AiBC1 loading/execution
+  - deterministic state transition engine
+  - syscall dispatch boundary only (`sys.*`)
+  - no language-spec ownership changes without `SPEC/` updates
+- `src/AiCLI` is bootloader-only:
+  - CLI arg parsing and mode selection
+  - syscall host binding
+  - delegates execution to core/vm layers
+- `src/AiVectra` is UI-layer placeholder (no active runtime integration yet).
+
 ## What the AI is allowed to do
 
 - Implement tokenizer, parser, validator, interpreter, REPL.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,21 @@ AiLang is an AI-first language/runtime project using AI-Optimized Syntax (AOS) a
 This root README is human-oriented.  
 For agent-focused operating docs, use `Docs/README.md`.
 
+## Architecture
+
+AiLang is organized into four explicit layers under `src/`:
+
+- `src/AiLang.Core` — language layer (AOS AST model, parser bridge, validator, formatter wiring, semantic helpers).
+- `src/AiVM.Core` — deterministic VM/runtime engine (AiBC1 load/run + syscall dispatch boundary).
+- `src/AiCLI` — executable bootloader and CLI argument handling (`run`, `serve`, `repl`, `bench`).
+- `src/AiVectra` — UI-layer placeholder for future integration.
+
+Layer rule:
+
+- C# host effects are only reachable through `sys.*`.
+- VM is canonical runtime execution.
+- AST interpreter exists only for debug (`--vm=ast` in dev mode).
+
 ## Project Identity
 
 This repository is itself an AiLang project.


### PR DESCRIPTION
Summary
- Refresh architecture documentation related to issue 38
- Ensure the high-level descriptions match the latest repo structure

Testing
- Not run (not requested)