### PR TITLE
Add sys.time_nowUnixMs syscall plumbing and tests

### DIFF
--- a/src/AiVM.Core/DefaultSyscallHost.cs
+++ b/src/AiVM.Core/DefaultSyscallHost.cs
@@ -16,6 +16,8 @@ public class DefaultSyscallHost : ISyscallHost
 
     public virtual string[] ProcessArgv() => EmptyArgv;
 
+    public virtual int TimeNowUnixMs() => unchecked((int)DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+
     public virtual void ConsoleWriteErrLine(string text) => Console.Error.WriteLine(text);
 
     public virtual void ConsoleWrite(string text) => Console.Write(text);

--- a/src/AiVM.Core/ISyscallHost.cs
+++ b/src/AiVM.Core/ISyscallHost.cs
@@ -4,6 +4,7 @@ public interface ISyscallHost
 {
     string[] ProcessArgv();
     string ProcessEnvGet(string name);
+    int TimeNowUnixMs();
     void ConsoleWriteErrLine(string text);
     void ConsoleWrite(string text);
     string ProcessCwd();

--- a/src/AiVM.Core/SyscallContracts.cs
+++ b/src/AiVM.Core/SyscallContracts.cs
@@ -96,6 +96,10 @@ public static class SyscallContracts
                 ValidateArityAndType(argKinds, 1, VmValueKind.String, "VAL191", "sys.process_envGet expects 1 argument.", "VAL192", "sys.process_envGet arg must be string.", addDiagnostic);
                 returnKind = VmValueKind.String;
                 return true;
+            case "sys.time_nowUnixMs":
+                ValidateArity(argKinds, 0, "VAL182", "sys.time_nowUnixMs expects 0 arguments.", addDiagnostic);
+                returnKind = VmValueKind.Int;
+                return true;
             case "sys.stdout_writeLine":
                 ValidateArityAndType(argKinds, 1, VmValueKind.String, "VAL134", "sys.stdout_writeLine expects 1 argument.", "VAL135", "sys.stdout_writeLine arg must be string.", addDiagnostic);
                 returnKind = VmValueKind.Void;

--- a/src/AiVM.Core/VmSyscallDispatcher.cs
+++ b/src/AiVM.Core/VmSyscallDispatcher.cs
@@ -19,6 +19,7 @@ public static class VmSyscallDispatcher
             "sys.console_writeErrLine" or
             "sys.process_cwd" or
             "sys.process_envGet" or
+            "sys.time_nowUnixMs" or
             "sys.stdout_writeLine" or
             "sys.proc_exit" or
             "sys.fs_readFile" or
@@ -53,6 +54,7 @@ public static class VmSyscallDispatcher
             "sys.console_writeErrLine" => 1,
             "sys.process_cwd" => 0,
             "sys.process_envGet" => 1,
+            "sys.time_nowUnixMs" => 0,
             "sys.stdout_writeLine" => 1,
             "sys.proc_exit" => 1,
             "sys.fs_readFile" => 1,
@@ -150,6 +152,13 @@ public static class VmSyscallDispatcher
                     return true;
                 }
                 result = SysValue.String(VmSyscalls.ProcessEnvGet(envName));
+                return true;
+            case "sys.time_nowUnixMs":
+                if (args.Count != 0)
+                {
+                    return true;
+                }
+                result = SysValue.Int(VmSyscalls.TimeNowUnixMs());
                 return true;
             case "sys.console_writeLine":
                 if (!TryGetString(args, 0, 1, out var consoleLineText))

--- a/src/AiVM.Core/VmSyscalls.cs
+++ b/src/AiVM.Core/VmSyscalls.cs
@@ -14,6 +14,11 @@ public static class VmSyscalls
         return Host.ProcessEnvGet(name);
     }
 
+    public static int TimeNowUnixMs()
+    {
+        return Host.TimeNowUnixMs();
+    }
+
     public static void ConsoleWriteErrLine(string text)
     {
         Host.ConsoleWriteErrLine(text);


### PR DESCRIPTION
Summary:\n- add TimeNowUnixMs to ISyscallHost and DefaultSyscallHost\n- wire sys.time_nowUnixMs through VM syscall dispatcher and contract validation\n- add unit tests for host passthrough and syscall dispatch behavior\n\nValidation:\n- ./scripts/test.sh (pass)