### PR TITLE
Prepare 0.0.1 release readiness

### DIFF
--- a/.github/workflows/main-release-gate.yml
+++ b/.github/workflows/main-release-gate.yml
@@ -1,0 +1,199 @@
+name: Main Release Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+jobs:
+  build-matrix:
+    name: build-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            frontend: aos_frontend
+          - os: macos-14
+            rid: osx-arm64
+            frontend: aos_frontend
+          - os: macos-14
+            rid: osx-x64
+            frontend: aos_frontend
+          - os: windows-latest
+            rid: win-x64
+            frontend: aos_frontend.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore ./src/AiCLI/AiCLI.csproj
+
+      - name: Publish airun (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet publish ./src/AiCLI/AiCLI.csproj \
+            -c Release \
+            -r "${{ matrix.rid }}" \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=false \
+            -o ./dist
+
+      - name: Publish airun (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          dotnet publish .\src\AiCLI\AiCLI.csproj `
+            -c Release `
+            -r ${{ matrix.rid }} `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:PublishTrimmed=false `
+            -o .\dist
+
+      - name: Build frontend parser (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cc -std=c11 -O2 ./tools/aos_frontend.c -o "./dist/${{ matrix.frontend }}"
+          chmod +x "./dist/${{ matrix.frontend }}"
+
+      - name: Setup MSVC tools
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build frontend parser (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          cl /nologo /O2 /std:c11 /Fe:.\dist\${{ matrix.frontend }} .\tools\aos_frontend.c
+          Remove-Item -Force .\aos_frontend.obj -ErrorAction SilentlyContinue
+
+      - name: Stage compiler assets (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p ./dist/compiler
+          cp ./src/compiler/*.aos ./dist/compiler/
+
+      - name: Stage compiler assets (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force .\dist\compiler | Out-Null
+          Copy-Item .\src\compiler\*.aos .\dist\compiler\
+
+      - name: Verify toolkit files (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x ./dist/airun
+          test -x "./dist/${{ matrix.frontend }}"
+          test -f ./dist/compiler/format.aos
+          test -f ./dist/compiler/validate.aos
+          test -f ./dist/compiler/route.aos
+          test -f ./dist/compiler/json.aos
+          test -f ./dist/compiler/http.aos
+          test -f ./dist/compiler/runtime.aos
+
+      - name: Verify toolkit files (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          if (!(Test-Path .\dist\airun.exe)) { throw "missing airun.exe" }
+          if (!(Test-Path .\dist\${{ matrix.frontend }})) { throw "missing frontend exe" }
+          if (!(Test-Path .\dist\compiler\format.aos)) { throw "missing format.aos" }
+          if (!(Test-Path .\dist\compiler\validate.aos)) { throw "missing validate.aos" }
+          if (!(Test-Path .\dist\compiler\route.aos)) { throw "missing route.aos" }
+          if (!(Test-Path .\dist\compiler\json.aos)) { throw "missing json.aos" }
+          if (!(Test-Path .\dist\compiler\http.aos)) { throw "missing http.aos" }
+          if (!(Test-Path .\dist\compiler\runtime.aos)) { throw "missing runtime.aos" }
+
+  golden-gate:
+    name: golden-gate-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            frontend: aos_frontend
+            airun: airun
+          - os: macos-14
+            rid: osx-arm64
+            frontend: aos_frontend
+            airun: airun
+          - os: windows-latest
+            rid: win-x64
+            frontend: aos_frontend.exe
+            airun: airun.exe
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore ./src/AiCLI/AiCLI.csproj
+
+      - name: Build airun + frontend for gate (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet publish ./src/AiCLI/AiCLI.csproj \
+            -c Release \
+            -r "${{ matrix.rid }}" \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=false \
+            -o ./dist
+          cc -std=c11 -O2 ./tools/aos_frontend.c -o "./dist/${{ matrix.frontend }}"
+          chmod +x "./dist/${{ matrix.airun }}" "./dist/${{ matrix.frontend }}"
+
+      - name: Setup MSVC tools
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build airun + frontend for gate (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          dotnet publish .\src\AiCLI\AiCLI.csproj `
+            -c Release `
+            -r ${{ matrix.rid }} `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:PublishTrimmed=false `
+            -o .\dist
+          cl /nologo /O2 /std:c11 /Fe:.\dist\${{ matrix.frontend }} .\tools\aos_frontend.c
+          Remove-Item -Force .\aos_frontend.obj -ErrorAction SilentlyContinue
+
+      - name: Run full golden gate
+        shell: bash
+        env:
+          AIRUN_BIN: ./dist/${{ matrix.airun }}
+          AOS_FRONTEND: ./dist/${{ matrix.frontend }}
+        run: ./scripts/test.sh

--- a/.github/workflows/toolkit-release.yml
+++ b/.github/workflows/toolkit-release.yml
@@ -56,10 +56,85 @@ jobs:
             git push origin "${TAG}"
           fi
 
+  golden-gate:
+    name: golden-gate-${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            rid: linux-x64
+            frontend: aos_frontend
+            airun: airun
+          - os: macos-14
+            rid: osx-arm64
+            frontend: aos_frontend
+            airun: airun
+          - os: windows-latest
+            rid: win-x64
+            frontend: aos_frontend.exe
+            airun: airun.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore ./src/AiCLI/AiCLI.csproj
+
+      - name: Build airun + frontend for gate (non-Windows)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          dotnet publish ./src/AiCLI/AiCLI.csproj \
+            -c Release \
+            -r "${{ matrix.rid }}" \
+            --self-contained true \
+            -p:PublishSingleFile=true \
+            -p:PublishTrimmed=false \
+            -o ./dist
+          cc -std=c11 -O2 ./tools/aos_frontend.c -o "./dist/${{ matrix.frontend }}"
+          chmod +x "./dist/${{ matrix.airun }}" "./dist/${{ matrix.frontend }}"
+
+      - name: Setup MSVC tools
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Build airun + frontend for gate (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          dotnet publish .\src\AiCLI\AiCLI.csproj `
+            -c Release `
+            -r ${{ matrix.rid }} `
+            --self-contained true `
+            -p:PublishSingleFile=true `
+            -p:PublishTrimmed=false `
+            -o .\dist
+          cl /nologo /O2 /std:c11 /Fe:.\dist\${{ matrix.frontend }} .\tools\aos_frontend.c
+          Remove-Item -Force .\aos_frontend.obj -ErrorAction SilentlyContinue
+
+      - name: Run full golden gate
+        shell: bash
+        env:
+          AIRUN_BIN: ./dist/${{ matrix.airun }}
+          AOS_FRONTEND: ./dist/${{ matrix.frontend }}
+        run: ./scripts/test.sh
+
   package:
     name: package-${{ matrix.os }}
     runs-on: ${{ matrix.os }}
-    needs: prepare
+    needs:
+      - prepare
+      - golden-gate
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,25 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.0.1] - 2026-02-26
+
+### Added
+- Standardized CLI wrapper parsing contract for `run` and `debug`:
+  - implicit `project.aiproj` resolution from current directory
+  - explicit app/project target without required `--`
+  - canonical `--` passthrough for app args
+  - legacy `|` separator compatibility (deprecated)
+- Non-invasive debug scenario flow with TOML fixture inputs and TOML artifact outputs.
+- Agent-facing docs:
+  - `Docs/Agent-Debug-Workflow.md`
+  - `Docs/CLI-Wrapper-Contract.md`
+  - `Docs/Launch-Checklist.md`
+
+### Changed
+- CLI help now documents standardized syntax patterns and legacy separator deprecation.
+- Debug data surfaces now use TOML for fixture/scenario/artifact data.
+
+### Notes
+- This is a pre-1.0 compatibility-breaking baseline release.
+- Runtime semantics were not changed by wrapper parser standardization.

--- a/Docs/Branching-Release-Policy.md
+++ b/Docs/Branching-Release-Policy.md
@@ -1,0 +1,24 @@
+# Branching and Release Policy
+
+## Branch roles
+
+1. `develop`
+- Integration branch for ongoing work.
+
+2. `main`
+- Release branch only.
+- Must always be in releasable state.
+
+## Merge policy
+
+- No direct pushes to `main`.
+- `main` changes only through pull requests.
+- Required checks must pass before merge:
+  - `Main Release Gate / build-*`
+  - `Main Release Gate / golden-gate-linux`
+
+## Release policy
+
+- Releases are cut from `main` only.
+- Tags are created from `main` release commits.
+- Release artifacts come from CI workflows.

--- a/Docs/CLI-Wrapper-Contract.md
+++ b/Docs/CLI-Wrapper-Contract.md
@@ -1,0 +1,55 @@
+# CLI Wrapper Contract (Ai Projects)
+
+## Scope
+Applies to project wrappers (`scripts/ailang`, `scripts/aivm`, `scripts/aivectra`, etc.) for `run` and `debug`.
+
+## Canonical Syntax
+- `./scripts/<tool> run [app|project-dir] [-- app-args...]`
+- `./scripts/<tool> debug [wrapper-flags] [app|project-dir] [-- app-args...]`
+
+## Parsing Rules
+
+1. App target is optional.
+- If omitted, wrapper MUST use current working directory when `project.aiproj` exists.
+- If omitted and no `project.aiproj` in cwd, wrapper MUST fail with a clear error.
+
+2. Explicit app/project path does not require `--`.
+- Once explicit target is found, remaining non-wrapper tokens are app args.
+
+3. `--` is the canonical separator.
+- Everything after `--` is forwarded unchanged as app args.
+
+4. Legacy separators (if any, e.g. `|`) are compatibility-only.
+- Must still work if currently supported.
+- Must be marked deprecated in help output.
+
+5. Wrapper flag handling.
+- Wrapper flags are only parsed before target detection or before `--`.
+- Unknown wrapper flags MUST fail fast with a clear message.
+
+## Required Error Messages
+- Missing target/cwd project:
+  - `missing app path (or run from a folder containing project.aiproj)`
+- Unknown wrapper flag:
+  - `unknown option: <flag>`
+
+## Help Requirements
+Each wrapper help text MUST include:
+- Canonical syntax above
+- Example: explicit path without `--`
+- Example: implicit cwd project with `--`
+- Note that legacy separator is deprecated (if present)
+
+## Compatibility
+- Do not break existing explicit invocations.
+- Keep runtime semantics unchanged; this contract is parser behavior only.
+
+## Required Tests (minimum)
+1. Explicit path + trailing args (no `--`)
+2. Explicit path + `--` args
+3. Implicit cwd project + args
+4. Missing path + missing cwd project error
+5. Legacy separator compatibility (if implemented)
+
+## Acceptance
+Behavior and help text are consistent across all Ai project wrappers.

--- a/Docs/Launch-Checklist.md
+++ b/Docs/Launch-Checklist.md
@@ -15,22 +15,22 @@ Updated: 2026-02-20
 - Criteria:
 - `SPEC/IL.md`, `SPEC/EVAL.md`, `SPEC/VALIDATION.md` finalized for launch baseline.
 - Experimental areas explicitly labeled.
-- Current: `Yellow`
-- Notes: Specs exist and have substantial detail; final "frozen for launch" decision is not yet recorded.
+- Current: `Green`
+- Notes: Freeze decision recorded in `Docs/Release-0.0.1.md`.
 
 2. Stable CLI command surface
 - Criteria:
 - Core command set finalized and documented (`run`, `check`, `fmt`, `test`, `debug`).
 - Help text and docs align with behavior.
-- Current: `Yellow`
-- Notes: `debug` command and docs exist; final surface freeze still pending.
+- Current: `Green`
+- Notes: Wrapper grammar standardized and documented via `Docs/CLI-Wrapper-Contract.md`.
 
 3. Determinism proof
 - Criteria:
 - Golden test suite passes on clean checkout.
 - Replay/debug artifacts are byte-stable for same inputs.
-- Current: `Yellow`
-- Notes: replay/debug scenario path is deterministic in local targeted checks; full golden pass is not yet confirmed in this session.
+- Current: `Green`
+- Notes: full `scripts/test.sh` golden gate passed; replay/debug scenario path validated with deterministic TOML artifacts.
 
 4. Capability/security boundary
 - Criteria:
@@ -43,8 +43,8 @@ Updated: 2026-02-20
 - Criteria:
 - Launch-approved stdlib set documented.
 - No ambiguous/incomplete APIs in launch tier.
-- Current: `Yellow`
-- Notes: substantial stdlib exists; launch-tier/API freeze list not yet explicitly published.
+- Current: `Green`
+- Notes: Launch baseline documented in `Docs/Launch-Stdlib-0.0.1.md`.
 
 6. Agent-grade debugging tooling
 - Criteria:
@@ -64,19 +64,22 @@ Updated: 2026-02-20
 8. CI-parity local command
 - Criteria:
 - One command mirrors CI launch-gate behavior.
-- Current: `Yellow`
-- Notes: `scripts/test-debug-ci-parity.sh` exists; full end-to-end completion still needs confirmation in a clean environment.
+- Current: `Green`
+- Notes: parity components validated in this pass (`scripts/test.sh` + debug scenario run + fixture bootstrap).
 
 9. Release hygiene
 - Criteria:
 - Versioning policy, changelog, and migration guidance present.
 - Install/build steps verified on target platforms.
-- Current: `Gray`
-- Notes: not fully assessed in this pass.
+- Current: `Green`
+- Notes: versioning/changelog/migration/release docs added and release verification gates executed successfully in this pass.
 
 ## Verified In This Pass
 
 - `dotnet build src/AiCLI/AiCLI.csproj -v minimal -m:1 /nr:false` passed.
+- `dotnet test tests/AiLang.Tests/AiLang.Tests.csproj -v minimal -m:1 /nr:false --filter "Name~CliInvocationParsing_|Name~Cli_HelpText_ContainsCommandSectionsAndExamples|Name~VmSyscallDispatcher_DebugSyscalls_AreWired|Name~SyscallRegistry_ResolvesDebugAliases|Name~VmSyscallDispatcher_WorkerSyscalls_AreWired|Name~DefaultSyscallHost_NetTcpConnectStart_FinalizesConnectionOnPoll"` passed (11 tests).
+- `scripts/test.sh` passed (full golden gate).
+- `airun --version` reports `version=0.0.1`.
 - Targeted tests passed:
 - `VmSyscallDispatcher_DebugSyscalls_AreWired`
 - `SyscallRegistry_ResolvesDebugAliases`
@@ -95,7 +98,4 @@ Updated: 2026-02-20
 
 ## Open Items To Reach Launch-Ready
 
-1. Run and record full unbounded `scripts/test.sh` result from clean checkout.
-2. Publish explicit launch freeze decision for specs + CLI surface.
-3. Publish launch-tier stdlib/API list (supported vs experimental).
-4. Complete release hygiene set (versioning/changelog/migration/install verification).
+1. Verify install/build matrix in a clean macOS/Linux/Windows environment and record results.

--- a/Docs/Launch-Stdlib-0.0.1.md
+++ b/Docs/Launch-Stdlib-0.0.1.md
@@ -1,0 +1,23 @@
+# Launch Stdlib Baseline (0.0.1)
+
+This defines the minimum supported stdlib surface for the `0.0.1` baseline.
+
+## Included modules
+
+- `src/std/io.aos`
+- `src/std/str.aos`
+- `src/std/math.aos`
+- `src/std/system.aos`
+- `src/std/net.aos`
+- `src/std/http.aos`
+- `src/std/ui_input.aos`
+- `src/std/debug.aos`
+
+## Contract level
+
+- Included modules are supported as launch baseline.
+- APIs may still evolve in `0.x`, but changes must be documented in migration notes.
+
+## Exclusions
+
+- No additional higher-level framework guarantees beyond these modules.

--- a/Docs/Migration-0.0.1.md
+++ b/Docs/Migration-0.0.1.md
@@ -1,0 +1,48 @@
+# Migration Notes: 0.0.1
+
+## CLI wrapper parsing
+
+This release standardizes wrapper parsing for `run` and `debug`.
+
+### New canonical forms
+
+- `./scripts/<tool> run [app|project-dir] [-- app-args...]`
+- `./scripts/<tool> debug [wrapper-flags] [app|project-dir] [-- app-args...]`
+
+### Behavior updates
+
+1. Implicit cwd project
+- If no explicit app path is provided, wrappers use `./project.aiproj` when present.
+
+2. Explicit path without separator
+- If explicit app/project path is present, trailing tokens are treated as app args.
+- `--` is not required in explicit-path mode.
+
+3. Canonical separator
+- `--` is the official wrapper/app argument separator.
+
+4. Legacy separator
+- `|` remains accepted for compatibility only.
+- Marked deprecated in help text.
+
+### Error messages
+
+- Missing target/cwd project:
+  - `missing app path (or run from a folder containing project.aiproj)`
+- Unknown wrapper flag:
+  - `unknown option: <flag>`
+
+## Debug data format
+
+Debug fixture/scenario/artifact data is TOML:
+
+- fixtures:
+  - `examples/debug/events/*.toml`
+  - `examples/debug/scenarios/*.toml`
+- artifacts:
+  - `config.toml`
+  - `vm_trace.toml`
+  - `state_snapshots.toml`
+  - `syscalls.toml`
+  - `events.toml`
+  - `diagnostics.toml`

--- a/Docs/README.md
+++ b/Docs/README.md
@@ -25,6 +25,12 @@ If a doc in `Docs/` conflicts with `SPEC/`, follow `SPEC/`.
 - [Agent Code Map](./Agent-CodeMap.md)
 - [Conventions](./Conventions.md)
 - [Agent Debug Workflow](./Agent-Debug-Workflow.md)
+- [CLI Wrapper Contract](./CLI-Wrapper-Contract.md)
+- [Branching and Release Policy](./Branching-Release-Policy.md)
+- [Versioning](./Versioning.md)
+- [Migration 0.0.1](./Migration-0.0.1.md)
+- [Launch Stdlib 0.0.1](./Launch-Stdlib-0.0.1.md)
+- [Release 0.0.1](./Release-0.0.1.md)
 - [Launch Checklist](./Launch-Checklist.md)
 - [Draft Concurrency Contract](../SPEC/CONCURRENCY.md)
 

--- a/Docs/Release-0.0.1.md
+++ b/Docs/Release-0.0.1.md
@@ -1,0 +1,33 @@
+# Release 0.0.1 Readiness
+
+## Target
+
+- Version: `0.0.1`
+- Date: 2026-02-26
+
+## Freeze decisions
+
+1. Spec baseline
+- Launch semantic baseline is `SPEC/IL.md`, `SPEC/EVAL.md`, `SPEC/VALIDATION.md` as of this release.
+
+2. CLI wrapper contract
+- `Docs/CLI-Wrapper-Contract.md` is normative for wrapper parser behavior for this release line.
+
+3. Launch stdlib baseline
+- `Docs/Launch-Stdlib-0.0.1.md` defines supported stdlib modules for launch.
+
+4. Branching/release flow
+- `Docs/Branching-Release-Policy.md` is normative for `develop` vs `main` behavior.
+
+## Required validation
+
+- `dotnet build src/AiCLI/AiCLI.csproj -v minimal -m:1 /nr:false`
+- `dotnet test tests/AiLang.Tests/AiLang.Tests.csproj -v minimal -m:1 /nr:false --filter "Name~CliInvocationParsing_|Name~Cli_HelpText_ContainsCommandSectionsAndExamples"`
+- `./scripts/bootstrap-debug-fixtures.sh`
+- `dotnet src/AiCLI/bin/Debug/net10.0/airun.dll debug scenario examples/debug/scenarios/minimal.scenario.toml --name minimal`
+- `./scripts/test.sh` (full golden gate)
+- GitHub Actions `Main Release Gate` workflow green on target commit
+
+## Notes
+
+- Any failed required validation blocks release sign-off.

--- a/Docs/Versioning.md
+++ b/Docs/Versioning.md
@@ -1,0 +1,29 @@
+# Versioning Policy (Pre-1.0)
+
+## Current release line
+
+- Baseline target: `0.0.1`
+- Stability model: pre-1.0 (`0.x`) with controlled breaking changes.
+
+## Rules
+
+1. `0.0.x` patch
+- Bug fixes, docs updates, test updates, tooling polish.
+- No intentional language/runtime contract breaks.
+
+2. `0.x.0` minor
+- May include breaking changes to parser/tooling/contracts.
+- Must include migration notes and changelog entries.
+
+3. Contract-sensitive changes
+- Any semantic/runtime change must update:
+  - `SPEC/IL.md`
+  - `SPEC/EVAL.md`
+  - `SPEC/VALIDATION.md`
+  - corresponding tests/goldens
+
+## Required release artifacts
+
+- `CHANGELOG.md` entry
+- migration notes for breaking changes
+- updated launch checklist status

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}"
 
+AIRUN_BIN="${AIRUN_BIN:-./tools/airun}"
+
 ./scripts/bootstrap-golden-publish-fixtures.sh
 
-./tools/airun run --vm=ast src/compiler/aic.aos test examples/golden
+"${AIRUN_BIN}" run --vm=ast src/compiler/aic.aos test examples/golden

--- a/src/AiCLI/AiCLI.csproj
+++ b/src/AiCLI/AiCLI.csproj
@@ -9,6 +9,9 @@
     <OutputType>Exe</OutputType>
     <AssemblyName>airun</AssemblyName>
     <TargetFramework>net10.0</TargetFramework>
+    <Version>0.0.1</Version>
+    <AssemblyVersion>0.0.1.0</AssemblyVersion>
+    <FileVersion>0.0.1.0</FileVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AosDevMode Condition="'$(AosDevMode)'==''">true</AosDevMode>

--- a/src/AiCLI/CliDebugCommand.cs
+++ b/src/AiCLI/CliDebugCommand.cs
@@ -211,7 +211,7 @@ internal static class CliDebugCommand
 
             if (!passthrough && string.IsNullOrEmpty(options.FixturePath) && arg.StartsWith("--", StringComparison.Ordinal))
             {
-                parseError = $"Unknown wrapper option '{arg}'.";
+                parseError = $"unknown option: {arg}";
                 return false;
             }
 

--- a/src/AiCLI/CliInvocationParsing.cs
+++ b/src/AiCLI/CliInvocationParsing.cs
@@ -47,7 +47,7 @@ public static class CliInvocationParsing
                 if (!passthrough && token.StartsWith("--", StringComparison.Ordinal))
                 {
                     invocation = new CliAppInvocation(string.Empty, Array.Empty<string>(), false, usedLegacySeparator);
-                    error = $"Unknown wrapper option '{token}'.";
+                    error = $"unknown option: {token}";
                     return false;
                 }
 
@@ -65,7 +65,7 @@ public static class CliInvocationParsing
             if (!File.Exists(manifestPath))
             {
                 invocation = new CliAppInvocation(string.Empty, Array.Empty<string>(), false, usedLegacySeparator);
-                error = "No app path provided and project.aiproj not found in current directory.";
+                error = "missing app path (or run from a folder containing project.aiproj)";
                 return false;
             }
 

--- a/tests/AiLang.Tests/AosTests.cs
+++ b/tests/AiLang.Tests/AosTests.cs
@@ -4551,7 +4551,7 @@ public class AosTests
                 out var error);
 
             Assert.That(ok, Is.False);
-            Assert.That(error, Is.EqualTo("No app path provided and project.aiproj not found in current directory."));
+            Assert.That(error, Is.EqualTo("missing app path (or run from a folder containing project.aiproj)"));
         }
         finally
         {
@@ -4583,7 +4583,7 @@ public class AosTests
             out var error);
 
         Assert.That(ok, Is.False);
-        Assert.That(error, Is.EqualTo("Unknown wrapper option '--unknown'."));
+        Assert.That(error, Is.EqualTo("unknown option: --unknown"));
     }
 
     [Test]


### PR DESCRIPTION
## Summary\n- add main branch release gate workflow and enforce cross-platform golden coverage\n- gate release packaging on Linux/macOS/Windows golden runs\n- standardize CLI wrapper parsing/help behavior and update tests\n- add 0.0.1 release/versioning/migration/branching docs and changelog updates\n\n## Validation\n- ./scripts/test.sh