### PR TITLE
Use canonical runtime for installed CLI execution

### DIFF
--- a/Docs/Tasks/Finish-Self-Hosted-Lowering.md
+++ b/Docs/Tasks/Finish-Self-Hosted-Lowering.md
@@ -924,6 +924,22 @@ Validation boundary:
 - the optional performance harness currently reports its existing string
   benchmark type mismatch in both smoke and full modes.
 
+### Canonical installed runtime invocation
+
+Status: implemented and validated on 2026-07-29.
+
+Installed bytecode execution now resolves the SDK-owned `aivm-runtime` and uses
+the canonical `run <artifact> -- <application arguments>` contract. Runtime
+selection and argument construction live in the focused
+`src/cli/runtime_invocation.aos` module instead of the large CLI facade.
+
+The focused argument golden, complete CLI contract suite, and installed
+bytecode CLI gate pass. The published beta.53 self-host compiled the complete
+updated CLI project, and that generated CLI built and ran the restored
+`std-json` package application through the installed runtime boundary. This
+removes the `DEV008` failure that followed the package-owned
+`std.json.stringify` correction.
+
 ## Acceptance Criteria
 
 - [ ] `lower.aos` is a thin facade; lowering families live in focused modules.

--- a/scripts/test-ailang-cli-spec.sh
+++ b/scripts/test-ailang-cli-spec.sh
@@ -485,13 +485,15 @@ printf '%s\n' "${MULTI_STDOUT_OUT}" | rg -q '^second$'
 mkdir -p "${FAKE_INSTALL_ROOT}/local/bin" "${FAKE_INSTALL_ROOT}/local/libexec/ailang/cli"
 cp "${AIVM_BIN}" "${FAKE_INSTALL_ROOT}/local/bin/aivm"
 chmod +x "${FAKE_INSTALL_ROOT}/local/bin/aivm"
+cp "${ROOT_DIR}/tools/aivm-runtime" "${FAKE_INSTALL_ROOT}/local/bin/aivm-runtime"
+chmod +x "${FAKE_INSTALL_ROOT}/local/bin/aivm-runtime"
 cp "${CLI_BYTECODE_DIR}/app.aibc1" "${FAKE_INSTALL_ROOT}/local/libexec/ailang/cli/app.aibc1"
 cat > "${FAKE_INSTALL_ROOT}/local/bin/ailang" <<'EOF'
 #!/usr/bin/env sh
 set -eu
 SDK_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 export AILANG_SDK_ROOT="$SDK_ROOT"
-exec "$SDK_ROOT/bin/aivm" "$SDK_ROOT/libexec/ailang/cli/app.aibc1" "$@"
+exec "$SDK_ROOT/bin/aivm-runtime" run "$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "$@"
 EOF
 chmod +x "${FAKE_INSTALL_ROOT}/local/bin/ailang"
 if file "${FAKE_INSTALL_ROOT}/local/bin/ailang" | grep -Eiq 'Mach-O|ELF|PE32'; then
@@ -540,8 +542,10 @@ UNAVAILABLE_TARGET_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" publi
 printf '%s\n' "${UNAVAILABLE_TARGET_OUT}" | rg -q 'code=AILANG019'
 unset AILANG_INSTALL_ROOT
 
-run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" run "${APP_DIR}" >/dev/null
-AIVM="${AIVM_BIN}" run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" run "${BUILD_DIR}/app.aibc1" >/dev/null
+AIVM="${ROOT_DIR}/tools/aivm-runtime" \
+  run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" run "${APP_DIR}" >/dev/null
+AIVM="${ROOT_DIR}/tools/aivm-runtime" \
+  run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" run "${BUILD_DIR}/app.aibc1" >/dev/null
 
 mkdir -p "${APP_DIR}/bin" "${APP_DIR}/dist" "${APP_DIR}/.toolchain"
 touch "${APP_DIR}/bin/app.aibc1" "${APP_DIR}/dist/app.aibc1" "${APP_DIR}/.toolchain/cache"

--- a/scripts/test-installed-bytecode-cli.sh
+++ b/scripts/test-installed-bytecode-cli.sh
@@ -41,7 +41,7 @@ set -eu
 SDK_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 export AILANG_SDK_ROOT="$SDK_ROOT"
 export AILANG_SDK_VERSION="0.0.1-test.0"
-exec "$SDK_ROOT/bin/aivm" "$SDK_ROOT/libexec/ailang/cli/app.aibc1" "$@"
+exec "$SDK_ROOT/bin/aivm-runtime" run "$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "$@"
 EOF
 chmod +x "${SDK_ROOT}/bin/ailang"
 
@@ -72,7 +72,11 @@ EOF
 perl -0pi -e 's{\Q'"${APP_DIR}"': no app args\E}{app: no app args}' "${APP_DIR}/src/app.aos"
 PROJECT_VERSION_OUT="$("${SDK_ROOT}/bin/ailang" project version "${APP_DIR}")"
 printf '%s\n' "${PROJECT_VERSION_OUT}" | rg -q '^0\.0\.1$'
-AILANG_PACKAGE_REGISTRY="${PACKAGE_REGISTRY_DIR}" "${SDK_ROOT}/bin/ailang" package restore "${APP_DIR}" | rg -q 'Ok#ok1\(type=int value=0\)'
+PACKAGE_RESTORE_OUT="$(
+  AILANG_PACKAGE_REGISTRY="${PACKAGE_REGISTRY_DIR}" \
+    "${SDK_ROOT}/bin/ailang" package restore "${APP_DIR}"
+)"
+rg -q 'Ok#ok1\(type=int value=0\)' <<<"${PACKAGE_RESTORE_OUT}"
 test -f "${APP_DIR}/ailang.lock.toml"
 rg -q '^aivmVersion = "0\.0\.1-rc\.9"$' "${SDK_ROOT}/sdk-runtime.toml"
 

--- a/scripts/test-local-toolchain-shim.sh
+++ b/scripts/test-local-toolchain-shim.sh
@@ -15,7 +15,7 @@ if rg -n 'copy_if_exists "\$\{AILANG_DIR\}/tools/ailang" "\$\{TMP_ROOT\}/bin/ail
 fi
 
 rg -q 'write_sdk_ailang_shim' "${SCRIPT}"
-rg -q 'exec "\$SDK_ROOT/bin/aivm" "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" "\$@"' "${SCRIPT}"
+rg -q 'exec "\$SDK_ROOT/bin/aivm-runtime" run "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "\$@"' "${SCRIPT}"
 rg -q 'staged ailang must be a non-C shim' "${SCRIPT}"
 
 if rg -n 'cp "\./\$\{\{ matrix\.artifact_dir \}\}/\$\{\{ matrix\.tool \}\}" "\$\{PACKAGE_DIR\}/bin/ailang"' "${RELEASE_WORKFLOW}" >/tmp/ailang-release-shim-copy.out; then
@@ -30,7 +30,7 @@ if rg -n 'Copy-Item "\.\\\\\$\{\{ matrix\.artifact_dir \}\}\\\\\$\{\{ matrix\.to
   exit 1
 fi
 
-rg -q 'exec "\$SDK_ROOT/bin/aivm" "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" "\$@"' "${RELEASE_WORKFLOW}"
+rg -q 'exec "\$SDK_ROOT/bin/aivm-runtime" run "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "\$@"' "${RELEASE_WORKFLOW}"
 rg -q 'release package violation: bin/ailang must be a non-C shim' "${RELEASE_WORKFLOW}"
 rg -q 'ailang\.cmd' "${RELEASE_WORKFLOW}"
 rg -q 'release package violation: bin/ailang\.exe must not be staged as native command' "${RELEASE_WORKFLOW}"

--- a/scripts/test-runtime-invocation-module.sh
+++ b/scripts/test-runtime-invocation-module.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="${ROOT_DIR}/.tmp/runtime-invocation-module"
+
+rm -rf "${TMP_DIR}"
+mkdir -p "${TMP_DIR}"
+
+cat >"${TMP_DIR}/app.aos" <<'AOS'
+Program {
+  Import(path="../../src/cli/runtime_invocation.aos")
+  Export(name=start)
+
+  Let(name=start) {
+    Fn() {
+      Block {
+        Let(name=applicationArgs) {
+          AppendChild {
+            AppendChild {
+              AppendChild {
+                MakeBlock { Lit(value="args") }
+                MakeLitString {
+                  Lit(value="arg0")
+                  Lit(value="run")
+                }
+              }
+              MakeLitString {
+                Lit(value="arg1")
+                Lit(value="/work/app.aibc1")
+              }
+            }
+            MakeLitString {
+              Lit(value="arg2")
+              Lit(value="payload")
+            }
+          }
+        }
+        Let(name=runtimeArgs) {
+          Call(target=runtimeInvocation.arguments) {
+            Lit(value=true)
+            Lit(value="/work/app.aibc1")
+            Var(name=applicationArgs)
+          }
+        }
+        Call(target=sys.stdout.writeLine) {
+          Call(target=runtimeInvocation.executable)
+        }
+        Call(target=sys.stdout.writeLine) {
+          ToString { ChildCount { Var(name=runtimeArgs) } }
+        }
+        Call(target=sys.stdout.writeLine) {
+          AttrValueString {
+            ChildAt { Var(name=runtimeArgs) Lit(value=0) }
+            Lit(value=0)
+          }
+        }
+        Call(target=sys.stdout.writeLine) {
+          AttrValueString {
+            ChildAt { Var(name=runtimeArgs) Lit(value=1) }
+            Lit(value=0)
+          }
+        }
+        Call(target=sys.stdout.writeLine) {
+          AttrValueString {
+            ChildAt { Var(name=runtimeArgs) Lit(value=2) }
+            Lit(value=0)
+          }
+        }
+        Call(target=sys.stdout.writeLine) {
+          AttrValueString {
+            ChildAt { Var(name=runtimeArgs) Lit(value=3) }
+            Lit(value=0)
+          }
+        }
+        Return { Lit(value=0) }
+      }
+    }
+  }
+}
+AOS
+
+AILANG_SDK_ROOT="${ROOT_DIR}/src" \
+  "${ROOT_DIR}/tools/ailang" build "${TMP_DIR}/app.aos" \
+  --out "${TMP_DIR}" --no-cache >/dev/null
+
+actual="$(
+  env -u AIVM AILANG_SDK_ROOT="/sdk-test" \
+    "${ROOT_DIR}/tools/aivm-runtime" run "${TMP_DIR}/app.aibc1"
+)"
+
+expected="$(
+  cat <<'TEXT'
+/sdk-test/bin/aivm-runtime
+4
+run
+/work/app.aibc1
+--
+payload
+Ok#ok1(type=int value=0)
+TEXT
+)"
+
+if [[ "${actual}" != "${expected}" ]]; then
+  diff -u <(printf '%s\n' "${expected}") <(printf '%s\n' "${actual}")
+  exit 1
+fi
+
+echo "runtime invocation module: PASS"

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -67,6 +67,7 @@ bash ./scripts/check-doc-taxonomy.sh
 ./scripts/test-selfhost-transitive-module-symbol-pipeline.sh
 ./scripts/test-object-linker-structural-call-module.sh
 ./scripts/test-clean-bootstrap-routing.sh
+./scripts/test-runtime-invocation-module.sh
 ./scripts/test-local-toolchain-shim.sh
 ./scripts/test-installed-bytecode-cli.sh
 ./scripts/test-validator-unknown-kind.sh

--- a/scripts/update-local-toolchain.sh
+++ b/scripts/update-local-toolchain.sh
@@ -184,7 +184,7 @@ set -eu
 SDK_ROOT="\$(CDPATH= cd -- "\$(dirname -- "\$0")/../../.." && pwd)"
 export AILANG_SDK_ROOT="\$SDK_ROOT"
 export AILANG_COMMAND_NAME="${name}"
-exec "\$SDK_ROOT/bin/aivm" "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" "${name}" "\$@"
+exec "\$SDK_ROOT/bin/aivm-runtime" run "\$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "${name}" "\$@"
 EOF
   chmod +x "${path}"
 }
@@ -198,7 +198,7 @@ set -eu
 SDK_ROOT="$(CDPATH= cd -- "$(dirname -- "$0")/.." && pwd)"
 export AILANG_SDK_ROOT="$SDK_ROOT"
 export AILANG_SDK_VERSION="local"
-exec "$SDK_ROOT/bin/aivm" "$SDK_ROOT/libexec/ailang/cli/app.aibc1" "$@"
+exec "$SDK_ROOT/bin/aivm-runtime" run "$SDK_ROOT/libexec/ailang/cli/app.aibc1" -- "$@"
 EOF
   chmod +x "${path}"
 }

--- a/src/cli/ailang.aos
+++ b/src/cli/ailang.aos
@@ -10,6 +10,7 @@ Program {
   Import(path="manifest.aos")
   Import(path="target_packages.aos")
   Import(path="application.aos")
+  Import(path="runtime_invocation.aos")
   Export(name=main)
 
   Let(name=main) {
@@ -983,7 +984,13 @@ Program {
     Fn(params=path,args) {
       Block {
         Let(name=compilerPath) { Call(target=resolveBootstrapCompilerForRun) { Var(name=path) } }
-        Let(name=spawnArgs) { Call(target=makeRunSpawnArgs) { Var(name=path) Var(name=args) } }
+        Let(name=spawnArgs) {
+          Call(target=runtimeInvocation.arguments) {
+            Call(target=isBytecodePath) { Var(name=path) }
+            Var(name=path)
+            Var(name=args)
+          }
+        }
         Let(name=env) { MakeBlock { Lit(value="env") } }
         Let(name=handle) { Call(target=spawn) { Var(name=compilerPath) Var(name=spawnArgs) Lit(value="") Var(name=env) } }
         Let(name=code) { Call(target=wait) { Var(name=handle) } }
@@ -1009,87 +1016,12 @@ Program {
       Block {
         If {
           Call(target=isBytecodePath) { Var(name=path) }
-          Block { Return { Call(target=resolveAivmExecutable) { Lit(value=0) } } }
+          Block {
+            Return {
+              Call(target=runtimeInvocation.executable)
+            }
+          }
           Block { Return { Call(target=resolveBootstrapCompiler) { Var(name=path) } } }
-        }
-      }
-    }
-  }
-
-  Let(name=resolveAivmExecutable) {
-    Fn(params=_) {
-      Block {
-        Let(name=fromEnv) { Call(target=sys.process.env.get) { Lit(value="AIVM") } }
-        If {
-          Eq { Var(name=fromEnv) Lit(value="") }
-          Block { Return { Lit(value="aivm") } }
-          Block { Return { Var(name=fromEnv) } }
-        }
-      }
-    }
-  }
-
-  Let(name=makeRunSpawnArgs) {
-    Fn(params=path,args) {
-      Block {
-        If {
-          Call(target=isBytecodePath) { Var(name=path) }
-          Block {
-            Return {
-              Call(target=appendRunAppArgs) {
-                AppendChild {
-                  MakeBlock { Lit(value="args") }
-                  MakeLitString { Lit(value="arg0") Var(name=path) }
-                }
-                Var(name=args)
-                Lit(value=2)
-                Lit(value=1)
-              }
-            }
-          }
-          Block {
-            Return {
-              Call(target=appendRunAppArgs) {
-                AppendChild {
-                  AppendChild {
-                    MakeBlock { Lit(value="args") }
-                    MakeLitString { Lit(value="arg0") Lit(value="run") }
-                  }
-                  MakeLitString { Lit(value="arg1") Var(name=path) }
-                }
-                Var(name=args)
-                Lit(value=2)
-                Lit(value=2)
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  Let(name=appendRunAppArgs) {
-    Fn(params=spawnArgs,args,readIndex,writeIndex) {
-      Block {
-        If {
-          Eq { Var(name=readIndex) ChildCount { Var(name=args) } }
-          Block { Return { Var(name=spawnArgs) } }
-          Block {
-            Return {
-              Call(target=appendRunAppArgs) {
-                AppendChild {
-                  Var(name=spawnArgs)
-                  MakeLitString {
-                    StrConcat { Lit(value="arg") ToString { Var(name=writeIndex) } }
-                    Call(target=readArg) { Var(name=args) Var(name=readIndex) }
-                  }
-                }
-                Var(name=args)
-                Add { Var(name=readIndex) Lit(value=1) }
-                Add { Var(name=writeIndex) Lit(value=1) }
-              }
-            }
-          }
         }
       }
     }

--- a/src/cli/runtime_invocation.aos
+++ b/src/cli/runtime_invocation.aos
@@ -1,0 +1,143 @@
+Program {
+  Import(sdk="ailang" path="std/process.aos")
+
+  Export(name=runtimeInvocation.executable)
+  Export(name=runtimeInvocation.arguments)
+
+  Let(name=runtimeInvocation.executable) {
+    Fn() {
+      Block {
+        Let(name=explicitRuntime) {
+          Call(target=envGet) {
+            Lit(value="AIVM")
+          }
+        }
+        If {
+          Eq { Var(name=explicitRuntime) Lit(value="") }
+          Block {
+            Let(name=sdkRoot) {
+              Call(target=envGet) {
+                Lit(value="AILANG_SDK_ROOT")
+              }
+            }
+            If {
+              Eq { Var(name=sdkRoot) Lit(value="") }
+              Block { Return { Lit(value="aivm-runtime") } }
+              Block {
+                Return {
+                  StrConcat {
+                    Var(name=sdkRoot)
+                    Lit(value="/bin/aivm-runtime")
+                  }
+                }
+              }
+            }
+          }
+          Block { Return { Var(name=explicitRuntime) } }
+        }
+      }
+    }
+  }
+
+  Let(name=runtimeInvocation.arguments) {
+    Fn(params=isBytecode,path,args) {
+      Block {
+        If {
+          Var(name=isBytecode)
+          Block {
+            Return {
+              Call(target=runtimeInvocation.appendAppArguments) {
+                AppendChild {
+                  AppendChild {
+                    AppendChild {
+                      MakeBlock { Lit(value="args") }
+                      MakeLitString {
+                        Lit(value="arg0")
+                        Lit(value="run")
+                      }
+                    }
+                    MakeLitString {
+                      Lit(value="arg1")
+                      Var(name=path)
+                    }
+                  }
+                  MakeLitString {
+                    Lit(value="arg2")
+                    Lit(value="--")
+                  }
+                }
+                Var(name=args)
+                Lit(value=2)
+                Lit(value=3)
+              }
+            }
+          }
+          Block {
+            Return {
+              Call(target=runtimeInvocation.appendAppArguments) {
+                AppendChild {
+                  AppendChild {
+                    MakeBlock { Lit(value="args") }
+                    MakeLitString {
+                      Lit(value="arg0")
+                      Lit(value="run")
+                    }
+                  }
+                  MakeLitString {
+                    Lit(value="arg1")
+                    Var(name=path)
+                  }
+                }
+                Var(name=args)
+                Lit(value=2)
+                Lit(value=2)
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=runtimeInvocation.appendAppArguments) {
+    Fn(params=spawnArgs,args,readIndex,writeIndex) {
+      Block {
+        If {
+          Eq { Var(name=readIndex) ChildCount { Var(name=args) } }
+          Block { Return { Var(name=spawnArgs) } }
+          Block {
+            Return {
+              Call(target=runtimeInvocation.appendAppArguments) {
+                AppendChild {
+                  Var(name=spawnArgs)
+                  MakeLitString {
+                    StrConcat {
+                      Lit(value="arg")
+                      ToString { Var(name=writeIndex) }
+                    }
+                    AttrValueString {
+                      ChildAt {
+                        Var(name=args)
+                        Var(name=readIndex)
+                      }
+                      Lit(value=0)
+                    }
+                  }
+                }
+                Var(name=args)
+                Add {
+                  Var(name=readIndex)
+                  Lit(value=1)
+                }
+                Add {
+                  Var(name=writeIndex)
+                  Lit(value=1)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- extracts installed runtime selection and argument construction into focused `src/cli/runtime_invocation.aos`
- executes bytecode through `aivm-runtime run <artifact> -- <args>`
- updates local, release-aligned, and test SDK shims to the canonical contract
- adds a focused runtime invocation regression to the canonical test entrypoint
- records the completed self-host acceptance evidence

## Why

The installed CLI still invoked generated bytecode with the deprecated direct `aivm <artifact>` shape. Packaged `aivm` uses the `aivm-runtime` command surface, so package runs reached `DEV008` after compilation succeeded.

## Impact

Self-hosted installed builds and runs now use one SDK-owned runtime boundary consistently. No AiVM or language semantics changed.

## Validation

- `./test.sh`
- `./scripts/test-runtime-invocation-module.sh`
- `./scripts/test-installed-bytecode-cli.sh`
- `./scripts/test-ailang-cli-spec.sh`
- published beta.53 self-host compiled the complete updated CLI
- generated CLI built and ran the std-json package application
- `git diff --check`