### PR TITLE
Accept expanded package namespace lists

### DIFF
--- a/scripts/test-installed-package-workflow.sh
+++ b/scripts/test-installed-package-workflow.sh
@@ -114,7 +114,7 @@ if ! grep -q 'std-app' "${TMP_ROOT}/template-package-list.txt"; then
   cat "${TMP_ROOT}/template-package-list.txt" >&2 || true
   exit 1
 fi
-if ! grep -q 'namespaces = \["std.app"\]' "${TMP_ROOT}/template-package-list.txt"; then
+if ! grep -q 'namespaces = .*"std.app"' "${TMP_ROOT}/template-package-list.txt"; then
   echo "std-app namespace missing from package list" >&2
   cat "${TMP_ROOT}/template-package-list.txt" >&2 || true
   exit 1


### PR DESCRIPTION
## What changed

The installed package workflow now checks that the `std-app` namespace list contains `std.app` instead of requiring the obsolete exact one-element list.

## Why

`std-app` correctly publishes additional focused namespaces (`std.app.global`, `std.app.event`, and others). Exact-list equality made the smoke test reject valid package metadata after the earlier std-json build blocker was removed.

## Validation

- public std-json alpha.6 restore/build/run passed
- the workflow advances through package build/run and std-app namespace validation
- `sh -n scripts/test-installed-package-workflow.sh`
- `git diff --check`

The next independent failure remains intentionally visible: installed package-template discovery does not yet list `aivectra/hello-name`.