### PR TITLE
Discover restored package template catalogs

### DIFF
--- a/Docs/AiLang-Packages.md
+++ b/Docs/AiLang-Packages.md
@@ -178,7 +178,10 @@ Publisher workflow:
 3. Put importable library source under nested domain paths in `src/`, such as
    `src/format/`, `src/net/`, `src/media/`, or `src/ui/`.
 4. Put package templates under `templates/projects/` or `templates/files/`
-   when the package exposes templates.
+   when the package exposes templates. Each populated template kind owns a
+   deterministic `index.toml` catalog in that directory. The CLI reads package
+   catalogs in lockfile order and qualifies each template as
+   `<package>/<template>`.
 5. Put package tools under the package-owned tool path once tool dispatch is
    hardened for beta.
 6. Run the package's own validation script.

--- a/Docs/Tasks/AiLang-Self-Hosting-Rewrite.md
+++ b/Docs/Tasks/AiLang-Self-Hosting-Rewrite.md
@@ -74,6 +74,11 @@ Current bootstrap status:
   first bytecode-runnable implementations.
 - `init` renders installed `.tpl` files under `templates/projects`. Missing
   template files are an error.
+- `template list projects|files <project-dir>` discovers restored package
+  template catalogs in canonical lockfile order. Package catalogs are
+  deterministic `templates/<kind>/index.toml` files; the AiLang command
+  qualifies entries as `<package>/<template>` without host directory
+  enumeration.
 - The self-hosted compiler pipeline already produces deterministic per-module
   AiBCO1 objects in `obj/module-<index>.aibco`, writes `obj/app.aibco` as the
   stable entry object, links `bin/app.aibc1`, and executes supported linked

--- a/scripts/test-ailang-cli-spec.sh
+++ b/scripts/test-ailang-cli-spec.sh
@@ -34,6 +34,7 @@ PACKAGE_RESTORE_DUP_DIR="${TMP_DIR}/package-restore-dup-app"
 PACKAGE_RESTORE_CYCLE_DIR="${TMP_DIR}/package-restore-cycle-app"
 PACKAGE_REGISTRY_DIR="${TMP_DIR}/package-registry"
 PACKAGE_SOURCE_REPO="${TMP_DIR}/package-source-repo"
+TEMPLATE_PACKAGE_DIR="${TMP_DIR}/template-package-app"
 
 run_aivm_program() {
   local program="$1"
@@ -90,6 +91,34 @@ printf '%s\n' "${TEMPLATE_SHOW_OUT}" | rg -q 'entry_file = "src/app.aos"'
 
 TEMPLATE_PATH_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" template path cli)"
 printf '%s\n' "${TEMPLATE_PATH_OUT}" | rg -q '^templates/projects/cli$'
+
+mkdir -p \
+  "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/projects/hello" \
+  "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/files/view"
+cat > "${TEMPLATE_PACKAGE_DIR}/ailang.lock.toml" <<'EOF'
+schema = "ailang.lock.v1"
+
+[[package]]
+name = "sample-kit"
+version = "0.0.1"
+path = ".ailang/packages/sample-kit"
+packageRoot = "."
+namespaces = []
+EOF
+cat > "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/projects/index.toml" <<'EOF'
+[[template]]
+name = "hello"
+path = "templates/projects/hello"
+EOF
+cat > "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/files/index.toml" <<'EOF'
+[[template]]
+name = "view"
+path = "templates/files/view"
+EOF
+TEMPLATE_PROJECTS_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" template list projects "${TEMPLATE_PACKAGE_DIR}")"
+printf '%s\n' "${TEMPLATE_PROJECTS_OUT}" | rg -q '^sample-kit/hello$'
+TEMPLATE_FILES_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" template list files "${TEMPLATE_PACKAGE_DIR}")"
+printf '%s\n' "${TEMPLATE_FILES_OUT}" | rg -q '^sample-kit/view$'
 
 run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" init "${APP_DIR}" --template cli-args --agents all >/dev/null
 test -f "${APP_DIR}/project.aiproj"

--- a/src/cli/Template/catalog.aos
+++ b/src/cli/Template/catalog.aos
@@ -1,0 +1,71 @@
+Program {
+  Import(path="../common.aos")
+  Import(path="package_catalog.aos")
+
+  Export(name=listTemplateCatalog)
+
+  Let(name=listTemplateCatalog) {
+    Fn(params=kind,projectDir) {
+      Block {
+        Let(name=builtin) { Call(target=builtinTemplateCatalog) { Var(name=kind) } }
+        Let(name=packages) { Call(target=packageTemplateCatalog) { Var(name=kind) Var(name=projectDir) } }
+        If {
+          Eq { Var(name=builtin) Lit(value="") }
+          Block {
+            If {
+              Eq { Var(name=packages) Lit(value="") }
+              Block { Return { Call(target=missingTemplateCatalog) { Var(name=kind) } } }
+              Block {
+                Call(target=sys.stdout.writeLine) { Var(name=packages) }
+                Return { Lit(value=0) }
+              }
+            }
+          }
+          Block {
+            Call(target=sys.stdout.writeLine) { Var(name=builtin) }
+            If {
+              Eq { Var(name=packages) Lit(value="") }
+              Block { Return { Lit(value=0) } }
+              Block {
+                Call(target=sys.stdout.writeLine) { Var(name=packages) }
+                Return { Lit(value=0) }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=builtinTemplateCatalog) {
+    Fn(params=kind) {
+      Block {
+        If {
+          Eq { Var(name=kind) Lit(value="projects") }
+          Block {
+            If {
+              Call(target=sys.fs.path.exists) { Lit(value="templates/projects/index.toml") }
+              Block { Return { Call(target=readTextFile) { Lit(value="templates/projects/index.toml") } } }
+              Block { Return { Lit(value="") } }
+            }
+          }
+          Block { Return { Lit(value="") } }
+        }
+      }
+    }
+  }
+
+  Let(name=missingTemplateCatalog) {
+    Fn(params=kind) {
+      Block {
+        Call(target=sys.stdout.writeLine) {
+          StrConcat {
+            Lit(value="Err#err0(code=AILANG005 message=\"Template registry is not installed.\" nodeId=\"template/")
+            StrConcat { Var(name=kind) Lit(value="\")") }
+          }
+        }
+        Return { Lit(value=1) }
+      }
+    }
+  }
+}

--- a/src/cli/Template/package_catalog.aos
+++ b/src/cli/Template/package_catalog.aos
@@ -1,0 +1,174 @@
+Program {
+  Import(sdk="ailang" path="std/str.aos")
+  Import(path="../common.aos")
+
+  Export(name=packageTemplateCatalog)
+
+  Let(name=packageTemplateCatalog) {
+    Fn(params=kind,projectDir) {
+      Block {
+        Let(name=lockPath) { StrConcat { Var(name=projectDir) Lit(value="/ailang.lock.toml") } }
+        Let(name=lockText) { Call(target=readOptionalLockText) { Var(name=lockPath) } }
+        Return { Call(target=packageCatalogFrom) { Var(name=kind) Var(name=projectDir) Var(name=lockText) Lit(value=0) } }
+      }
+    }
+  }
+
+  Let(name=packageCatalogFrom) {
+    Fn(params=kind,projectDir,lockText,startIndex) {
+      Block {
+        Let(name=sectionStart) { Call(target=find) { Var(name=lockText) Lit(value="[[package]]") Var(name=startIndex) } }
+        If {
+          Eq { Var(name=sectionStart) Lit(value=-1) }
+          Block { Return { Lit(value="") } }
+          Block {
+            Let(name=afterStart) { Add { Var(name=sectionStart) Lit(value=11) } }
+            Let(name=nextStart) { Call(target=find) { Var(name=lockText) Lit(value="[[package]]") Var(name=afterStart) } }
+            Let(name=section) { Call(target=lockSection) { Var(name=lockText) Var(name=sectionStart) Var(name=nextStart) } }
+            Let(name=packageName) { Call(target=quotedValue) { Var(name=section) Lit(value="name") } }
+            Let(name=packagePath) { Call(target=quotedValue) { Var(name=section) Lit(value="path") } }
+            Let(name=packageRoot) { Call(target=quotedValue) { Var(name=section) Lit(value="packageRoot") } }
+            Let(name=indexPath) {
+              Call(target=templateIndexPath) {
+                Var(name=projectDir)
+                Var(name=packagePath)
+                Var(name=packageRoot)
+                Var(name=kind)
+              }
+            }
+            Let(name=current) {
+              If {
+                Call(target=sys.fs.path.exists) { Var(name=indexPath) }
+                Block {
+                  Call(target=qualifiedIndexNames) {
+                    Var(name=packageName)
+                    Call(target=readTextFile) { Var(name=indexPath) }
+                    Lit(value=0)
+                  }
+                }
+                Block { Lit(value="") }
+              }
+            }
+            Let(name=nextIndex) {
+              If {
+                Eq { Var(name=nextStart) Lit(value=-1) }
+                Block { Lit(value=2147483647) }
+                Block { Var(name=nextStart) }
+              }
+            }
+            Return {
+              StrConcat {
+                Var(name=current)
+                Call(target=packageCatalogFrom) {
+                  Var(name=kind)
+                  Var(name=projectDir)
+                  Var(name=lockText)
+                  Var(name=nextIndex)
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=lockSection) {
+    Fn(params=text,startIndex,nextIndex) {
+      Block {
+        If {
+          Eq { Var(name=nextIndex) Lit(value=-1) }
+          Block { Return { Call(target=substring) { Var(name=text) Var(name=startIndex) Lit(value=2147483647) } } }
+          Block { Return { Call(target=substring) { Var(name=text) Var(name=startIndex) Sub { Var(name=nextIndex) Var(name=startIndex) } } } }
+        }
+      }
+    }
+  }
+
+  Let(name=quotedValue) {
+    Fn(params=text,key) {
+      Block {
+        Let(name=needle) { StrConcat { Var(name=key) Lit(value=" = \"") } }
+        Let(name=valueKey) { Call(target=find) { Var(name=text) Var(name=needle) Lit(value=0) } }
+        If {
+          Eq { Var(name=valueKey) Lit(value=-1) }
+          Block { Return { Lit(value="") } }
+          Block {
+            Let(name=valueStart) { Add { Var(name=valueKey) StringUtf8ByteCount { Var(name=needle) } } }
+            Let(name=rest) { Call(target=substring) { Var(name=text) Var(name=valueStart) Lit(value=2147483647) } }
+            Let(name=valueEnd) { Call(target=find) { Var(name=rest) Lit(value="\"") Lit(value=0) } }
+            If {
+              Eq { Var(name=valueEnd) Lit(value=-1) }
+              Block { Return { Lit(value="") } }
+              Block { Return { Call(target=substring) { Var(name=rest) Lit(value=0) Var(name=valueEnd) } } }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=templateIndexPath) {
+    Fn(params=projectDir,packagePath,packageRoot,kind) {
+      Block {
+        Let(name=restoredRoot) { StrConcat { Var(name=projectDir) StrConcat { Lit(value="/") Var(name=packagePath) } } }
+        Let(name=sourceRoot) {
+          If {
+            Eq { Var(name=packageRoot) Lit(value=".") }
+            Block { Var(name=restoredRoot) }
+            Block { StrConcat { Var(name=restoredRoot) StrConcat { Lit(value="/") Var(name=packageRoot) } } }
+          }
+        }
+        Return {
+          StrConcat {
+            Var(name=sourceRoot)
+            StrConcat { Lit(value="/templates/") StrConcat { Var(name=kind) Lit(value="/index.toml") } }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=qualifiedIndexNames) {
+    Fn(params=packageName,indexText,startIndex) {
+      Block {
+        Let(name=nameKey) { Call(target=find) { Var(name=indexText) Lit(value="name = \"") Var(name=startIndex) } }
+        If {
+          Eq { Var(name=nameKey) Lit(value=-1) }
+          Block { Return { Lit(value="") } }
+          Block {
+            Let(name=nameStart) { Add { Var(name=nameKey) Lit(value=8) } }
+            Let(name=rest) { Call(target=substring) { Var(name=indexText) Var(name=nameStart) Lit(value=2147483647) } }
+            Let(name=nameEnd) { Call(target=find) { Var(name=rest) Lit(value="\"") Lit(value=0) } }
+            If {
+              Eq { Var(name=nameEnd) Lit(value=-1) }
+              Block { Return { Lit(value="") } }
+              Block {
+                Let(name=templateName) { Call(target=substring) { Var(name=rest) Lit(value=0) Var(name=nameEnd) } }
+                Return {
+                  StrConcat {
+                    Var(name=packageName)
+                    StrConcat {
+                      Lit(value="/")
+                      StrConcat {
+                        Var(name=templateName)
+                        StrConcat {
+                          Lit(value="\n")
+                          Call(target=qualifiedIndexNames) {
+                            Var(name=packageName)
+                            Var(name=indexText)
+                            Add { Add { Var(name=nameStart) Var(name=nameEnd) } Lit(value=1) }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/cli/Template/template.aos
+++ b/src/cli/Template/template.aos
@@ -1,5 +1,6 @@
 Program {
   Import(path="../common.aos")
+  Import(path="catalog.aos")
   Export(name=runTemplate)
 
   Let(name=runTemplate) {
@@ -7,9 +8,26 @@ Program {
       Block {
         Let(name=subcmd) { Call(target=readArg) { Var(name=args) Lit(value=1) } }
         Let(name=name) { Call(target=readArg) { Var(name=args) Lit(value=2) } }
+        Let(name=projectDir) { Call(target=readArg) { Var(name=args) Lit(value=3) } }
         If {
           Eq { Var(name=subcmd) Lit(value="list") }
-          Block { Return { Call(target=listTemplates) { Lit(value=0) } } }
+          Block {
+            Let(name=kind) {
+              If {
+                Eq { Var(name=name) Lit(value="") }
+                Block { Lit(value="projects") }
+                Block { Var(name=name) }
+              }
+            }
+            Let(name=resolvedProjectDir) {
+              If {
+                Eq { Var(name=projectDir) Lit(value="") }
+                Block { Lit(value=".") }
+                Block { Var(name=projectDir) }
+              }
+            }
+            Return { Call(target=listTemplateCatalog) { Var(name=kind) Var(name=resolvedProjectDir) } }
+          }
           Block {
             If {
               Eq { Var(name=subcmd) Lit(value="show") }
@@ -67,26 +85,6 @@ Program {
           }
           Block {
             Call(target=sys.stdout.writeLine) { Lit(value="Err#err0(code=AILANG004 message=\"Unknown template.\" nodeId=\"template\")") }
-            Return { Lit(value=1) }
-          }
-        }
-      }
-    }
-  }
-
-  Let(name=listTemplates) {
-    Fn(params=_) {
-      Block {
-        If {
-          Call(target=sys.fs.path.exists) { Lit(value="templates/projects/index.toml") }
-          Block {
-            Call(target=sys.stdout.writeLine) {
-              Call(target=readTextFile) { Lit(value="templates/projects/index.toml") }
-            }
-            Return { Lit(value=0) }
-          }
-          Block {
-            Call(target=sys.stdout.writeLine) { Lit(value="Err#err0(code=AILANG005 message=\"Template registry is not installed.\" nodeId=\"template\")") }
             Return { Lit(value=1) }
           }
         }

--- a/src/cli/common.aos
+++ b/src/cli/common.aos
@@ -17,8 +17,7 @@ Program {
     Fn(params=args,index) {
       Block {
         If {
-          Eq { Var(name=index) ChildCount { Var(name=args) } }
-          Block { Return { Lit(value="") } }
+          Lt { Var(name=index) ChildCount { Var(name=args) } }
           Block {
             Return {
               AttrValueString {
@@ -27,6 +26,7 @@ Program {
               }
             }
           }
+          Block { Return { Lit(value="") } }
         }
       }
     }


### PR DESCRIPTION
Adds deterministic package template discovery in lockfile order through focused AiLang modules. Includes project/file catalog regression coverage, self-host migration documentation, and safe CLI argument bounds.\n\nValidated: ./test.sh; self-hosted built-in compilation and execution.