### PR TITLE
Dispatch restored package tools from self-hosted CLI

### DIFF
--- a/Docs/AiLang-Packages.md
+++ b/Docs/AiLang-Packages.md
@@ -259,6 +259,11 @@ resolution is:
 2. globally installed tool under `~/.ailang/tools`
 3. local package tool from the current project's lockfile
 
+The self-hosted CLI owns local package-tool resolution in focused
+`package_tool_dispatch.aos` and `package_lock_tools.aos` modules. It preserves
+compiled command priority, resolves restored package roots in canonical
+lockfile order, and forwards tool arguments through `std.process`.
+
 If a package declares `tool` and its tool name conflicts with a compiled,
 global, or already-local tool, restore fails instead of silently shadowing a
 command.

--- a/Docs/Tasks/AiLang-Self-Hosting-Rewrite.md
+++ b/Docs/Tasks/AiLang-Self-Hosting-Rewrite.md
@@ -79,6 +79,10 @@ Current bootstrap status:
   deterministic `templates/<kind>/index.toml` files; the AiLang command
   qualifies entries as `<package>/<template>` without host directory
   enumeration.
+- Unknown compiled command names now fall through to an AiLang-authored local
+  package-tool resolver. It reads the current project lockfile, resolves tools
+  in canonical package order, and invokes the selected executable through
+  `std.process`; the main CLI remains a thin facade.
 - The self-hosted compiler pipeline already produces deterministic per-module
   AiBCO1 objects in `obj/module-<index>.aibco`, writes `obj/app.aibco` as the
   stable entry object, links `bin/app.aibc1`, and executes supported linked

--- a/scripts/test-ailang-cli-spec.sh
+++ b/scripts/test-ailang-cli-spec.sh
@@ -94,7 +94,8 @@ printf '%s\n' "${TEMPLATE_PATH_OUT}" | rg -q '^templates/projects/cli$'
 
 mkdir -p \
   "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/projects/hello" \
-  "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/files/view"
+  "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/files/view" \
+  "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/scripts"
 cat > "${TEMPLATE_PACKAGE_DIR}/ailang.lock.toml" <<'EOF'
 schema = "ailang.lock.v1"
 
@@ -115,10 +116,20 @@ cat > "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/templates/files/index
 name = "view"
 path = "templates/files/view"
 EOF
+cat > "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/scripts/sample-kit" <<'EOF'
+#!/usr/bin/env sh
+printf 'sample-package-tool:%s\n' "$1"
+EOF
+chmod +x "${TEMPLATE_PACKAGE_DIR}/.ailang/packages/sample-kit/scripts/sample-kit"
 TEMPLATE_PROJECTS_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" template list projects "${TEMPLATE_PACKAGE_DIR}")"
 printf '%s\n' "${TEMPLATE_PROJECTS_OUT}" | rg -q '^sample-kit/hello$'
 TEMPLATE_FILES_OUT="$(run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" template list files "${TEMPLATE_PACKAGE_DIR}")"
 printf '%s\n' "${TEMPLATE_FILES_OUT}" | rg -q '^sample-kit/view$'
+TEMPLATE_TOOL_OUT="$(
+  cd "${TEMPLATE_PACKAGE_DIR}"
+  run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" sample-kit probe
+)"
+printf '%s\n' "${TEMPLATE_TOOL_OUT}" | rg -q '^sample-package-tool:probe$'
 
 run_aivm_program "${CLI_BYTECODE_DIR}/app.aibc1" init "${APP_DIR}" --template cli-args --agents all >/dev/null
 test -f "${APP_DIR}/project.aiproj"

--- a/scripts/test-installed-package-workflow.sh
+++ b/scripts/test-installed-package-workflow.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 TMP_ROOT="${AILANG_PACKAGE_SMOKE_ROOT:-$(mktemp -d "${TMPDIR:-/tmp}/ailang-package-smoke.XXXXXX")}"
 APP_DIR="${TMP_ROOT}/package-app"
 TEMPLATE_DIR="${TMP_ROOT}/template-app"
+BUILD_TIMEOUT_SECONDS="${AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS:-120}"
 
 cleanup() {
   if [[ -z "${AILANG_PACKAGE_SMOKE_KEEP:-}" ]]; then
@@ -22,6 +23,17 @@ require_tool() {
 require_tool ailang
 require_tool git
 require_tool perl
+
+case "${BUILD_TIMEOUT_SECONDS}" in
+  ''|*[!0-9]*)
+    echo "AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+if [[ "${BUILD_TIMEOUT_SECONDS}" -lt 1 ]]; then
+  echo "AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS must be at least 1" >&2
+  exit 2
+fi
 
 run_with_timeout() {
   local seconds="$1"
@@ -68,13 +80,13 @@ grep -q 'namespaces = \["std.format.json"\]' "${APP_DIR}/ailang.lock.toml"
 ailang package list "${APP_DIR}" >"${TMP_ROOT}/package-list.txt"
 grep -q 'std-json' "${TMP_ROOT}/package-list.txt"
 grep -q 'namespaces = \["std.format.json"\]' "${TMP_ROOT}/package-list.txt"
-if ! run_with_timeout 30 ailang build "${APP_DIR}" >"${TMP_ROOT}/package-build.stdout.txt" 2>"${TMP_ROOT}/package-build.stderr.txt"; then
+if ! run_with_timeout "${BUILD_TIMEOUT_SECONDS}" ailang build "${APP_DIR}" >"${TMP_ROOT}/package-build.stdout.txt" 2>"${TMP_ROOT}/package-build.stderr.txt"; then
   echo "package app build failed or timed out" >&2
   cat "${TMP_ROOT}/package-build.stdout.txt" >&2 || true
   cat "${TMP_ROOT}/package-build.stderr.txt" >&2 || true
   exit 1
 fi
-if ! run_with_timeout 30 ailang run "${APP_DIR}" >"${TMP_ROOT}/package-run.stdout.txt" 2>"${TMP_ROOT}/package-run.stderr.txt"; then
+if ! run_with_timeout "${BUILD_TIMEOUT_SECONDS}" ailang run "${APP_DIR}" >"${TMP_ROOT}/package-run.stdout.txt" 2>"${TMP_ROOT}/package-run.stderr.txt"; then
   echo "package app run failed or timed out" >&2
   cat "${TMP_ROOT}/package-run.stdout.txt" >&2 || true
   cat "${TMP_ROOT}/package-run.stderr.txt" >&2 || true

--- a/src/cli/ailang.aos
+++ b/src/cli/ailang.aos
@@ -10,13 +10,19 @@ Program {
   Import(path="manifest.aos")
   Import(path="target_packages.aos")
   Import(path="application.aos")
+  Import(path="package_tool_dispatch.aos")
   Import(path="runtime_invocation.aos")
   Export(name=main)
 
   Let(name=main) {
     Fn(params=args) {
       Block {
-        Return { Call(target=run) { Call(target=ailangCliApplication) { Lit(value=0) } Var(name=args) } }
+        Return {
+          Call(target=runAilangCommand) {
+            Call(target=ailangCliApplication) { Lit(value=0) }
+            Var(name=args)
+          }
+        }
       }
     }
   }

--- a/src/cli/package_lock_tools.aos
+++ b/src/cli/package_lock_tools.aos
@@ -1,0 +1,123 @@
+Program {
+  Import(sdk="ailang" path="std/str.aos")
+
+  Export(name=packageLockToolPath)
+
+  Let(name=packageLockToolPath) {
+    Fn(params=projectDir,lockText,toolName,startIndex) {
+      Block {
+        Let(name=sectionStart) { Call(target=find) { Var(name=lockText) Lit(value="[[package]]") Var(name=startIndex) } }
+        If {
+          Eq { Var(name=sectionStart) Lit(value=-1) }
+          Block { Return { Lit(value="") } }
+          Block {
+            Let(name=afterStart) { Add { Var(name=sectionStart) Lit(value=11) } }
+            Let(name=nextStart) { Call(target=find) { Var(name=lockText) Lit(value="[[package]]") Var(name=afterStart) } }
+            Let(name=section) {
+              If {
+                Eq { Var(name=nextStart) Lit(value=-1) }
+                Block { Call(target=substring) { Var(name=lockText) Var(name=sectionStart) Lit(value=2147483647) } }
+                Block { Call(target=substring) { Var(name=lockText) Var(name=sectionStart) Sub { Var(name=nextStart) Var(name=sectionStart) } } }
+              }
+            }
+            Let(name=packagePath) { Call(target=packageLockQuotedValue) { Var(name=section) Lit(value="path") } }
+            Let(name=packageRoot) { Call(target=packageLockQuotedValue) { Var(name=section) Lit(value="packageRoot") } }
+            Let(name=rootPath) { Call(target=packageSourceRoot) { Var(name=projectDir) Var(name=packagePath) Var(name=packageRoot) } }
+            Let(name=toolPath) { Call(target=toolPathInRoot) { Var(name=rootPath) Var(name=toolName) } }
+            If {
+              Eq { Var(name=toolPath) Lit(value="") }
+              Block {
+                Let(name=nextIndex) {
+                  If {
+                    Eq { Var(name=nextStart) Lit(value=-1) }
+                    Block { Lit(value=2147483647) }
+                    Block { Var(name=nextStart) }
+                  }
+                }
+                Return {
+                  Call(target=packageLockToolPath) {
+                    Var(name=projectDir)
+                    Var(name=lockText)
+                    Var(name=toolName)
+                    Var(name=nextIndex)
+                  }
+                }
+              }
+              Block { Return { Var(name=toolPath) } }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageLockQuotedValue) {
+    Fn(params=text,key) {
+      Block {
+        Let(name=needle) { StrConcat { Var(name=key) Lit(value=" = \"") } }
+        Let(name=valueKey) { Call(target=find) { Var(name=text) Var(name=needle) Lit(value=0) } }
+        If {
+          Eq { Var(name=valueKey) Lit(value=-1) }
+          Block { Return { Lit(value="") } }
+          Block {
+            Let(name=valueStart) { Add { Var(name=valueKey) StringUtf8ByteCount { Var(name=needle) } } }
+            Let(name=rest) { Call(target=substring) { Var(name=text) Var(name=valueStart) Lit(value=2147483647) } }
+            Let(name=valueEnd) { Call(target=find) { Var(name=rest) Lit(value="\"") Lit(value=0) } }
+            If {
+              Eq { Var(name=valueEnd) Lit(value=-1) }
+              Block { Return { Lit(value="") } }
+              Block { Return { Call(target=substring) { Var(name=rest) Lit(value=0) Var(name=valueEnd) } } }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageSourceRoot) {
+    Fn(params=projectDir,packagePath,packageRoot) {
+      Block {
+        Let(name=restoredRoot) { StrConcat { Var(name=projectDir) StrConcat { Lit(value="/") Var(name=packagePath) } } }
+        If {
+          Eq { Var(name=packageRoot) Lit(value=".") }
+          Block { Return { Var(name=restoredRoot) } }
+          Block { Return { StrConcat { Var(name=restoredRoot) StrConcat { Lit(value="/") Var(name=packageRoot) } } } }
+        }
+      }
+    }
+  }
+
+  Let(name=toolPathInRoot) {
+    Fn(params=rootPath,toolName) {
+      Block {
+        Let(name=toolsPath) { StrConcat { Var(name=rootPath) StrConcat { Lit(value="/tools/") Var(name=toolName) } } }
+        Let(name=binPath) { StrConcat { Var(name=rootPath) StrConcat { Lit(value="/bin/") Var(name=toolName) } } }
+        Let(name=scriptsPath) { StrConcat { Var(name=rootPath) StrConcat { Lit(value="/scripts/") Var(name=toolName) } } }
+        Let(name=rootToolPath) { StrConcat { Var(name=rootPath) StrConcat { Lit(value="/") Var(name=toolName) } } }
+        If {
+          Call(target=sys.fs.path.exists) { Var(name=toolsPath) }
+          Block { Return { Var(name=toolsPath) } }
+          Block {
+            If {
+              Call(target=sys.fs.path.exists) { Var(name=binPath) }
+              Block { Return { Var(name=binPath) } }
+              Block {
+                If {
+                  Call(target=sys.fs.path.exists) { Var(name=scriptsPath) }
+                  Block { Return { Var(name=scriptsPath) } }
+                  Block {
+                    If {
+                      Call(target=sys.fs.path.exists) { Var(name=rootToolPath) }
+                      Block { Return { Var(name=rootToolPath) } }
+                      Block { Return { Lit(value="") } }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/cli/package_tool_dispatch.aos
+++ b/src/cli/package_tool_dispatch.aos
@@ -1,0 +1,238 @@
+Program {
+  Import(package="std-cli" path="src/cli/cli.aos")
+  Import(sdk="ailang" path="std/bytes.aos")
+  Import(sdk="ailang" path="std/process.aos")
+  Import(path="package_lock_tools.aos")
+
+  Export(name=runAilangCommand)
+
+  Let(name=runAilangCommand) {
+    Fn(params=application,args) {
+      Block {
+        If {
+          Eq { ChildCount { Var(name=args) } Lit(value=0) }
+          Block { Return { Call(target=run) { Var(name=application) Var(name=args) } } }
+          Block {
+            Let(name=commandName) { Call(target=packageToolArg) { Var(name=args) Lit(value=0) } }
+            If {
+              Call(target=isBuiltInAilangCommand) { Var(name=commandName) }
+              Block { Return { Call(target=run) { Var(name=application) Var(name=args) } } }
+              Block {
+                Let(name=packageToolExit) { Call(target=runLocalPackageTool) { Var(name=args) } }
+                If {
+                  Eq { Var(name=packageToolExit) Lit(value=-1) }
+                  Block { Return { Call(target=run) { Var(name=application) Var(name=args) } } }
+                  Block { Return { Var(name=packageToolExit) } }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=isBuiltInAilangCommand) {
+    Fn(params=name) {
+      Block {
+        Return {
+          Call(target=packageToolOr) {
+            Call(target=packageToolOr) {
+              Call(target=packageToolOr) {
+                Call(target=packageToolOr) {
+                  Call(target=packageToolOr) {
+                    Call(target=packageToolOr) {
+                      Eq { Var(name=name) Lit(value="init") }
+                      Eq { Var(name=name) Lit(value="template") }
+                    }
+                    Eq { Var(name=name) Lit(value="agent") }
+                  }
+                  Eq { Var(name=name) Lit(value="build") }
+                }
+                Eq { Var(name=name) Lit(value="run") }
+              }
+              Call(target=isBuiltInAilangCommandTail) { Var(name=name) }
+            }
+            Call(target=isBuiltInAilangMetaCommand) { Var(name=name) }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=isBuiltInAilangCommandTail) {
+    Fn(params=name) {
+      Block {
+        Return {
+          Call(target=packageToolOr) {
+            Call(target=packageToolOr) {
+              Call(target=packageToolOr) {
+                Eq { Var(name=name) Lit(value="publish") }
+                Eq { Var(name=name) Lit(value="clean") }
+              }
+              Eq { Var(name=name) Lit(value="package") }
+            }
+            Eq { Var(name=name) Lit(value="project") }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=isBuiltInAilangMetaCommand) {
+    Fn(params=name) {
+      Block {
+        Return {
+          Call(target=packageToolOr) {
+            Call(target=packageToolOr) {
+              Call(target=packageToolOr) {
+                Eq { Var(name=name) Lit(value="help") }
+                Eq { Var(name=name) Lit(value="version") }
+              }
+              Call(target=packageToolOr) {
+                Eq { Var(name=name) Lit(value="--help") }
+                Eq { Var(name=name) Lit(value="-h") }
+              }
+            }
+            Eq { Var(name=name) Lit(value="--version") }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageToolOr) {
+    Fn(params=left,right) {
+      Block {
+        If {
+          Var(name=left)
+          Block { Return { Lit(value=true) } }
+          Block { Return { Var(name=right) } }
+        }
+      }
+    }
+  }
+
+  Let(name=runLocalPackageTool) {
+    Fn(params=args) {
+      Block {
+        Let(name=toolName) { Call(target=packageToolArg) { Var(name=args) Lit(value=0) } }
+        Let(name=projectDir) { Call(target=cwd) { Lit(value=0) } }
+        Let(name=lockPath) { StrConcat { Var(name=projectDir) Lit(value="/ailang.lock.toml") } }
+        If {
+          Eq { Call(target=sys.fs.path.exists) { Var(name=lockPath) } Lit(value=false) }
+          Block { Return { Lit(value=-1) } }
+          Block {
+            Let(name=lockText) {
+              Call(target=bytes.toUtf8String) {
+                Call(target=sys.fs.file.read) { Var(name=lockPath) }
+              }
+            }
+            Let(name=toolPath) {
+              Call(target=packageLockToolPath) {
+                Var(name=projectDir)
+                Var(name=lockText)
+                Var(name=toolName)
+                Lit(value=0)
+              }
+            }
+            If {
+              Eq { Var(name=toolPath) Lit(value="") }
+              Block { Return { Lit(value=-1) } }
+              Block {
+                Let(name=result) {
+                  Call(target=runCaptured) {
+                    Var(name=toolPath)
+                    Call(target=packageToolArguments) { Var(name=args) Lit(value=1) Lit(value=0) }
+                    Var(name=projectDir)
+                    MakeBlock { Lit(value="Environment") }
+                  }
+                }
+                Let(name=stdoutText) { Call(target=processResultStdoutText) { Var(name=result) } }
+                Let(name=stderrText) { Call(target=processResultStderrText) { Var(name=result) } }
+                If {
+                  Eq { Var(name=stdoutText) Lit(value="") }
+                  Block { Lit(value=0) }
+                  Block { Call(target=sys.stdout.writeLine) { Var(name=stdoutText) } }
+                }
+                If {
+                  Eq { Var(name=stderrText) Lit(value="") }
+                  Block { Lit(value=0) }
+                  Block { Call(target=sys.stdout.writeLine) { Var(name=stderrText) } }
+                }
+                Return { Call(target=processResultExitCode) { Var(name=result) } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageToolArguments) {
+    Fn(params=args,readIndex,writeIndex) {
+      Block {
+        If {
+          Eq { Var(name=readIndex) ChildCount { Var(name=args) } }
+          Block { Return { MakeBlock { Lit(value="Arguments") } } }
+          Block {
+            Return {
+              Call(target=packageToolAppendArguments) {
+                Var(name=args)
+                Var(name=readIndex)
+                Var(name=writeIndex)
+                MakeBlock { Lit(value="Arguments") }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageToolAppendArguments) {
+    Fn(params=args,readIndex,writeIndex,result) {
+      Block {
+        If {
+          Eq { Var(name=readIndex) ChildCount { Var(name=args) } }
+          Block { Return { Var(name=result) } }
+          Block {
+            Return {
+              Call(target=packageToolAppendArguments) {
+                Var(name=args)
+                Add { Var(name=readIndex) Lit(value=1) }
+                Add { Var(name=writeIndex) Lit(value=1) }
+                AppendChild {
+                  Var(name=result)
+                  MakeLitString {
+                    StrConcat { Lit(value="arg") ToString { Var(name=writeIndex) } }
+                    Call(target=packageToolArg) { Var(name=args) Var(name=readIndex) }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Let(name=packageToolArg) {
+    Fn(params=args,index) {
+      Block {
+        If {
+          Lt { Var(name=index) ChildCount { Var(name=args) } }
+          Block {
+            Return {
+              AttrValueString {
+                ChildAt { Var(name=args) Var(name=index) }
+                Lit(value=0)
+              }
+            }
+          }
+          Block { Return { Lit(value="") } }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Routes unknown compiled command names through focused AiLang-owned package lock and tool dispatch modules, preserving compiled command priority and forwarding arguments through std.process. Also replaces the CI-only 30-second package build alarm with a validated profile-controlled ceiling.\n\nValidated: focused CLI spec with package tool fixture; published beta.55 package build/run/template discovery; AiVectra package tool invocation; ./test.sh.