### PR TITLE
Allow pressure-bound release builds to finish

### DIFF
--- a/.github/workflows/toolkit-release.yml
+++ b/.github/workflows/toolkit-release.yml
@@ -791,8 +791,8 @@ jobs:
         shell: bash
         env:
           AILANG_EXAMPLES_ROOT: ${{ github.workspace }}/ailang-examples
-          AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS: 300
-          AILANG_WEATHER_BUILD_TIMEOUT_SECONDS: 300
+          AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS: 0
+          AILANG_WEATHER_BUILD_TIMEOUT_SECONDS: 0
         run: |
           set -euo pipefail
           export AILANG_INSTALL_ROOT="${RUNNER_TEMP}/ailang-exact"
@@ -815,8 +815,8 @@ jobs:
         shell: bash
         env:
           AILANG_EXAMPLES_ROOT: ${{ github.workspace }}/ailang-examples
-          AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS: 300
-          AILANG_WEATHER_BUILD_TIMEOUT_SECONDS: 300
+          AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS: 0
+          AILANG_WEATHER_BUILD_TIMEOUT_SECONDS: 0
         run: |
           set -euo pipefail
           export AILANG_INSTALL_ROOT="${RUNNER_TEMP}/ailang-channel"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project are documented in this file.
 
+## [0.0.1-beta.58] - 2026-08-05
+
+### Fixed
+
+- Removed per-command wall-clock alarms from release installation builds so a
+  resource-constrained hosted VM may complete slowly instead of being reported
+  as a semantic build failure.
+- Corrected the published Weather example document consumed by installation
+  smoke tests.
+
 ## [0.0.1-beta.57] - 2026-08-05
 
 ### Added

--- a/scripts/test-installed-package-workflow.sh
+++ b/scripts/test-installed-package-workflow.sh
@@ -22,22 +22,24 @@ require_tool() {
 
 require_tool ailang
 require_tool git
-require_tool perl
 
 case "${BUILD_TIMEOUT_SECONDS}" in
   ''|*[!0-9]*)
-    echo "AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS must be a positive integer" >&2
+    echo "AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS must be a non-negative integer" >&2
     exit 2
     ;;
 esac
-if [[ "${BUILD_TIMEOUT_SECONDS}" -lt 1 ]]; then
-  echo "AILANG_PACKAGE_BUILD_TIMEOUT_SECONDS must be at least 1" >&2
-  exit 2
+if [[ "${BUILD_TIMEOUT_SECONDS}" -gt 0 ]]; then
+  require_tool perl
 fi
 
 run_with_timeout() {
   local seconds="$1"
   shift
+  if [[ "${seconds}" -eq 0 ]]; then
+    "$@"
+    return
+  fi
   perl -e 'alarm shift @ARGV; exec @ARGV' "$seconds" "$@"
 }
 

--- a/scripts/test-installed-weather-workflow.sh
+++ b/scripts/test-installed-weather-workflow.sh
@@ -23,19 +23,15 @@ if ! command -v git >/dev/null 2>&1; then
   echo "missing required tool: git" >&2
   exit 1
 fi
-if ! command -v perl >/dev/null 2>&1; then
-  echo "missing required tool: perl" >&2
-  exit 1
-fi
 case "${BUILD_TIMEOUT_SECONDS}" in
   ''|*[!0-9]*)
-    echo "AILANG_WEATHER_BUILD_TIMEOUT_SECONDS must be a positive integer" >&2
+    echo "AILANG_WEATHER_BUILD_TIMEOUT_SECONDS must be a non-negative integer" >&2
     exit 2
     ;;
 esac
-if [[ "${BUILD_TIMEOUT_SECONDS}" -lt 1 ]]; then
-  echo "AILANG_WEATHER_BUILD_TIMEOUT_SECONDS must be at least 1" >&2
-  exit 2
+if [[ "${BUILD_TIMEOUT_SECONDS}" -gt 0 ]] && ! command -v perl >/dev/null 2>&1; then
+  echo "missing required tool: perl" >&2
+  exit 1
 fi
 if [[ ! -f "${EXAMPLE_DIR}/project.aiproj" ]]; then
   echo "weather example was not found: ${EXAMPLE_DIR}" >&2
@@ -54,7 +50,15 @@ grep -q 'name = "vectra-ui"' "${APP_DIR}/ailang.lock.toml"
 grep -q 'name = "std-http"' "${APP_DIR}/ailang.lock.toml"
 grep -q 'namespaces = .*"std.net.http"' "${APP_DIR}/ailang.lock.toml"
 
-if ! perl -e 'alarm shift @ARGV; exec @ARGV' "${BUILD_TIMEOUT_SECONDS}" ailang build "${APP_DIR}"; then
+run_build() {
+  if [[ "${BUILD_TIMEOUT_SECONDS}" -eq 0 ]]; then
+    ailang build "${APP_DIR}"
+    return
+  fi
+  perl -e 'alarm shift @ARGV; exec @ARGV' "${BUILD_TIMEOUT_SECONDS}" ailang build "${APP_DIR}"
+}
+
+if ! run_build; then
   echo "weather build failed or timed out" >&2
   exit 1
 fi


### PR DESCRIPTION
Removes per-command wall-clock alarms from release installation builds by defining timeout value 0 as unbounded. GitHub Actions remains the operational job safeguard. This prevents slow Linux compilation from being published as a semantic failure.\n\nAlso records the coordinated Weather example parse hotfix for beta.58.\n\nValidated: shell syntax, workflow YAML, zero-timeout routing, and whitespace checks.